### PR TITLE
Add contributors pictures to README, show pip install instructions in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,9 @@ or conda
 
 You can then `import skmatter` and use scikit-matter in your projects!
 
-.. contributing
+.. contributors
 
-Contributing
+Contributors
 ------------
 
 Thanks goes to all people that make scikit-matter possible:

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -1,6 +1,6 @@
 .. include:: ../../README.rst
    :start-after: installation
-   :end-before: contributing
+   :end-before: contributors
 
 Install from source
 -------------------


### PR DESCRIPTION
Closes #180

1. Detailed installation and developer instructions are shown in the docs and we now link to them from the `README.rst`. Also, developer avatars are shown in the README.

2. So far the `pip` and `conda` installation instructions are missing in the docs. I am using the `include` syntax of rst files to show these also in the docs _(This  is reason why I ported the README from markdown to rst)_.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--185.org.readthedocs.build/en/185/

<!-- readthedocs-preview scikit-matter end -->