### PR TITLE
Moving to doctest examples

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx.ext.doctest",
     "sphinx_gallery.gen_gallery",
     "sphinx_toggleprompt",
 ]

--- a/docs/src/preprocessing.rst
+++ b/docs/src/preprocessing.rst
@@ -1,7 +1,28 @@
 Preprocessing
 =============
 
-.. automodule:: skmatter.preprocessing
+
+KernelNormalizer
+----------------
+
+.. autoclass:: skmatter.preprocessing.KernelNormalizer
    :members:
    :undoc-members:
-   :show-inheritance:
+   :inherited-members:
+
+
+SparseKernelCenterer
+--------------------
+
+.. autoclass:: skmatter.preprocessing.SparseKernelCenterer
+   :members:
+   :undoc-members:
+   :inherited-members:
+
+StandardFlexibleScaler
+----------------------
+
+.. autoclass:: skmatter.preprocessing.StandardFlexibleScaler
+   :members:
+   :undoc-members:
+   :inherited-members:

--- a/docs/src/selection.rst
+++ b/docs/src/selection.rst
@@ -18,24 +18,46 @@ where at each iteration the model scores each
 feature or sample (without an estimator) and chooses that with the maximum score.
 This can be executed using:
 
-.. code-block:: python
+.. doctest::
 
-    selector = Selector(
-        # the number of selections to make
-        # if None, set to half the samples or features
-        # if float, fraction of the total dataset to select
-        # if int, absolute number of selections to make
-        n_to_select=4,
-        # option to use `tqdm <https://tqdm.github.io/>`_ progress bar
-        progress_bar=True,
-        # float, cutoff score to stop selecting
-        score_threshold=1e-12,
-        # boolean, whether to select randomly after non-redundant selections are exhausted
-        full=False,
-    )
-    selector.fit(X, y)
-
-    Xr = selector.transform(X)
+    >>> import numpy as np
+    >>> from skmatter.feature_selection import CUR, FPS, PCovCUR, PCovFPS
+    >>> selector = CUR(
+    ...     # the number of selections to make
+    ...     # if None, set to half the samples or features
+    ...     # if float, fraction of the total dataset to select
+    ...     # if int, absolute number of selections to make
+    ...     n_to_select=2,
+    ...     # option to use `tqdm <https://tqdm.github.io/>`_ progress bar
+    ...     progress_bar=True,
+    ...     # float, cutoff score to stop selecting
+    ...     score_threshold=1e-12,
+    ...     # boolean, whether to select randomly after non-redundant selections
+    ...     # are exhausted
+    ...     full=False,
+    ... )
+    >>> X = np.array([[ 0.12,  0.21,  0.02], # 3 samples, 3 features
+    ...               [-0.09,  0.32, -0.10],
+    ...               [-0.03, -0.53,  0.08]])
+    >>> y = np.array([0., 0., 1.])  # classes of each sample
+    >>> selector.fit(X)
+    CUR(n_to_select=2, progress_bar=True, score_threshold=1e-12)
+    >>> Xr = selector.transform(X)
+    >>> print(Xr.shape)
+    (3, 2)
+    >>> selector = PCovCUR(n_to_select=2)
+    >>> selector.fit(X, y)
+    PCovCUR(n_to_select=2)
+    >>> Xr = selector.transform(X)
+    >>> print(Xr.shape)
+    (3, 2)
+    >>> from skmatter.sample_selection import CUR, FPS, PCovCUR, PCovFPS
+    >>> selector = CUR(n_to_select=2)
+    >>> selector.fit(X)
+    CUR(n_to_select=2)
+    >>> Xr = X[selector.selected_idx_]
+    >>> print(Xr.shape)
+    (2, 3)
 
 where `Selector` is one of the classes below that overwrites the method
 :py:func:`score`.

--- a/docs/src/selection.rst
+++ b/docs/src/selection.rst
@@ -11,15 +11,12 @@ can be modified to combine supervised and unsupervised learning, in a formulatio
 denoted `PCov-CUR` and `PCov-FPS`.
 For further reading, refer to [Imbalzano2018]_ and [Cersonsky2021]_.
 
-
 These selectors can be used for both feature and sample selection, with similar
-instantiations. Currently, all sub-selection methods extend :py:class:`GreedySelector`,
-where at each iteration the model scores each
-feature or sample (without an estimator) and chooses that with the maximum score.
-This can be executed using:
+instantiations. This can be executed using:
 
 .. doctest::
 
+    >>> # feature selection
     >>> import numpy as np
     >>> from skmatter.feature_selection import CUR, FPS, PCovCUR, PCovFPS
     >>> selector = CUR(
@@ -36,10 +33,14 @@ This can be executed using:
     ...     # are exhausted
     ...     full=False,
     ... )
-    >>> X = np.array([[ 0.12,  0.21,  0.02], # 3 samples, 3 features
-    ...               [-0.09,  0.32, -0.10],
-    ...               [-0.03, -0.53,  0.08]])
-    >>> y = np.array([0., 0., 1.])  # classes of each sample
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> y = np.array([0.0, 0.0, 1.0])  # classes of each sample
     >>> selector.fit(X)
     CUR(n_to_select=2, progress_bar=True, score_threshold=1e-12)
     >>> Xr = selector.transform(X)
@@ -51,6 +52,8 @@ This can be executed using:
     >>> Xr = selector.transform(X)
     >>> print(Xr.shape)
     (3, 2)
+    >>>
+    >>> # Now sample selection
     >>> from skmatter.sample_selection import CUR, FPS, PCovCUR, PCovFPS
     >>> selector = CUR(n_to_select=2)
     >>> selector.fit(X)
@@ -59,23 +62,11 @@ This can be executed using:
     >>> print(Xr.shape)
     (2, 3)
 
-where `Selector` is one of the classes below that overwrites the method
-:py:func:`score`.
-
-From :py:class:`GreedySelector`, selectors inherit these public methods:
-
-.. currentmodule:: skmatter._selection
-
-.. class:: GreedySelector
-
-  .. automethod:: fit
-  .. automethod:: transform
-  .. automethod:: get_support
 
 .. _CUR-api:
 
 CUR
-###
+---
 
 
 CUR decomposition begins by approximating a matrix :math:`{\mathbf{X}}` using a subset
@@ -100,42 +91,24 @@ features in a single iteration based upon the relative :math:`\pi` importance.
 The feature and sample selection versions of CUR differ only in the computation of
 :math:`\pi`. In sample selection :math:`\pi` is computed using the left singular
 vectors, versus in feature selection, :math:`\pi` is computed using the right singular
-vectors. In addition to :py:class:`GreedySelector`, both instances of CUR selection
-build off of :py:class:`skmatter._selection._cur._CUR`, and inherit
+vectors.
 
-.. currentmodule:: skmatter._selection
+.. autoclass:: skmatter.feature_selection.CUR
+   :members:
+   :private-members: _compute_pi
+   :undoc-members:
+   :inherited-members:
 
-.. automethod:: _CUR.score
-.. automethod:: _CUR._compute_pi
-
-They are instantiated using
-:py:class:`skmatter.feature_selection.CUR` and
-:py:class:`skmatter.sample_selection.CUR`, e.g.
-
-.. code-block:: python
-
-    from skmatter.feature_selection import CUR
-
-    selector = CUR(
-        n_to_select=4,
-        progress_bar=True,
-        score_threshold=1e-12,
-        full=False,
-        # int, number of eigenvectors to use in computing pi
-        k=1,
-        # int, number of steps after which to recompute pi
-        recompute_every=1,
-        # float, threshold below which scores will be considered 0, defaults to 1E-12
-        tolerance=1e-12,
-    )
-    selector.fit(X)
-
-    Xr = selector.transform(X)
+.. autoclass:: skmatter.sample_selection.CUR
+   :members:
+   :private-members: _compute_pi
+   :undoc-members:
+   :inherited-members:
 
 .. _PCov-CUR-api:
 
 PCov-CUR
-########
+--------
 
 PCov-CUR extends upon CUR by using augmented right or left singular vectors inspired by
 Principal Covariates Regression, as demonstrated in [Cersonsky2021]_. These methods
@@ -143,45 +116,25 @@ employ the modified kernel and covariance matrices introduced in :ref:`PCovR-api
 available via the Utility Classes.
 
 Again, the feature and sample selection versions of PCov-CUR differ only in the
-computation of :math:`\pi`. So, in addition to :py:class:`GreedySelector`, both
-instances of PCov-CUR selection build off of
-:py:class:`skmatter._selection._cur._PCovCUR`, inheriting
+computation of :math:`\pi`. S
 
-.. currentmodule:: skmatter._selection
+.. autoclass:: skmatter.feature_selection.PCovCUR
+   :members:
+   :private-members: _compute_pi
+   :undoc-members:
+   :inherited-members:
 
-.. automethod:: _PCovCUR.score
-.. automethod:: _PCovCUR._compute_pi
+.. autoclass:: skmatter.sample_selection.PCovCUR
+   :members:
+   :private-members: _compute_pi
+   :undoc-members:
+   :inherited-members:
 
-and are instantiated using
-:py:class:`skmatter.feature_selection.PCovCUR` and :py:class:`skmatter.sample_selection.PCovCUR`.
-
-.. code-block:: python
-
-    from skmatter.feature_selection import PCovCUR
-
-    selector = PCovCUR(
-        n_to_select=4,
-        progress_bar=True,
-        score_threshold=1e-12,
-        full=False,
-        # float, default=0.5
-        # The PCovR mixing parameter, as described in PCovR as alpha
-        mixing=0.5,
-        # int, number of eigenvectors to use in computing pi
-        k=1,
-        # int, number of steps after which to recompute pi
-        recompute_every=1,
-        # float, threshold below which scores will be considered 0, defaults to 1E-12
-        tolerance=1e-12,
-    )
-    selector.fit(X, y)
-
-    Xr = selector.transform(X)
 
 .. _FPS-api:
 
 Farthest Point-Sampling (FPS)
-#############################
+-----------------------------
 
 Farthest Point Sampling is a common selection technique intended to exploit the
 diversity of the input space.
@@ -194,116 +147,53 @@ distance, however other distance metrics may be employed.
 Similar to CUR, the feature and selection versions of FPS differ only in the way
 distance is computed (feature selection does so column-wise, sample selection does so
 row-wise), and are built off of the same base class,
-:py:class:`skmatter._selection._fps._FPS`, in addition to GreedySelector, and inherit
-
-.. currentmodule:: skmatter._selection
-
-.. automethod:: _FPS.score
-.. automethod:: _FPS.get_distance
-.. automethod:: _FPS.get_select_distance
 
 These selectors can be instantiated using :py:class:`skmatter.feature_selection.FPS` and
 :py:class:`skmatter.sample_selection.FPS`.
 
-.. code-block:: python
 
-    from skmatter.feature_selection import FPS
+.. autoclass:: skmatter.feature_selection.FPS
+   :members:
+   :undoc-members:
+   :inherited-members:
 
-    selector = FPS(
-        n_to_select=4,
-        progress_bar=True,
-        score_threshold=1e-12,
-        full=False,
-        # int or 'random', default=0
-        # Index of the first selection.
-        # If ‘random’, picks a random value when fit starts.
-        initialize=0,
-    )
-    selector.fit(X)
-
-    Xr = selector.transform(X)
+.. autoclass:: skmatter.sample_selection.FPS
+   :members:
+   :undoc-members:
+   :inherited-members:
 
 .. _PCov-FPS-api:
 
 PCov-FPS
-########
+--------
 
 PCov-FPS extends upon FPS much like PCov-CUR does to CUR. Instead of using the Euclidean
 distance solely in the space of :math:`\mathbf{X}`, we use a combined distance in terms
 of :math:`\mathbf{X}` and :math:`\mathbf{y}`.
 
-Again, the feature and sample selection versions of PCov-FPS differ only in computing
-the distances. So, in addition to :py:class:`GreedySelector`, both instances of PCov-FPS
-selection build off of :py:class:`skmatter._selection._fps._PCovFPS`, and inherit
+.. autoclass:: skmatter.feature_selection.PCovFPS
+   :members:
+   :undoc-members:
+   :inherited-members:
 
-.. currentmodule:: skmatter._selection
-
-.. automethod:: _PCovFPS.score
-.. automethod:: _PCovFPS.get_distance
-.. automethod:: _PCovFPS.get_select_distance
-
-
-and can
-be instantiated using
-:py:class:`skmatter.feature_selection.PCovFPS` and :py:class:`skmatter.sample_selection.PCovFPS`.
-
-.. code-block:: python
-
-    from skmatter.feature_selection import PCovFPS
-
-    selector = PCovFPS(
-        n_to_select=4,
-        progress_bar=True,
-        score_threshold=1e-12,
-        full=False,
-        # float, default=0.5
-        # The PCovR mixing parameter, as described in PCovR as alpha
-        mixing=0.5,
-        # int or 'random', default=0
-        # Index of the first selection.
-        # If ‘random’, picks a random value when fit starts.
-        initialize=0,
-    )
-    selector.fit(X, y)
-
-    Xr = selector.transform(X)
+.. autoclass:: skmatter.sample_selection.PCovFPS
+   :members:
+   :undoc-members:
+   :inherited-members:
 
 .. _Voronoi-FPS-api:
 
 Voronoi FPS
-###########
+-----------
 
-.. currentmodule:: skmatter.sample_selection._voronoi_fps
+.. autoclass:: skmatter.sample_selection.VoronoiFPS
+   :members:
+   :undoc-members:
+   :inherited-members:
 
-.. autoclass :: VoronoiFPS
-
-These selectors can be instantiated using
-:py:class:`skmatter.sample_selection.VoronoiFPS`.
-
-.. code-block:: python
-
-    from skmatter.feature_selection import VoronoiFPS
-
-    selector = VoronoiFPS(
-        n_to_select=4,
-        progress_bar=True,
-        score_threshold=1e-12,
-        full=False,
-        # n_trial_calculation used for calculation of full_fraction,
-        # so you need to determine only one parameter
-        n_trial_calculation=4,
-        full_fraction=None,
-        # int or 'random', default=0
-        # Index of the first selection.
-        # If ‘random’, picks a random value when fit starts.
-        initialize=0,
-    )
-    selector.fit(X)
-
-    Xr = selector.transform(X)
 
 When *Not* to Use Voronoi FPS
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In many cases, this algorithm may not increase upon the efficiency. For example, for
 simple metrics (such as Euclidean distance), Voronoi FPS will likely not accelerate, and
@@ -315,27 +205,9 @@ bookkeeping significantly degrades the speed of work compared to FPS.
 .. _DCH-api:
 
 Directional Convex Hull (DCH)
-#############################
-.. currentmodule:: skmatter.sample_selection._base
+-----------------------------
 
-.. autoclass :: DirectionalConvexHull
-
-This selector can be instantiated using
-:class:`skmatter.sample_selection.DirectionalConvexHull`.
-
-.. code-block:: python
-
-    from skmatter.sample_selection import DirectionalConvexHull
-
-    selector = DirectionalConvexHull(
-        # Indices of columns of X to use for fitting
-        # the convex hull
-        low_dim_idx=[0, 1],
-    )
-    selector.fit(X, y)
-
-    # Get the distance to the convex hull for samples used to fit the
-    # convex hull. This can also be called using other samples (X_new)
-    # and corresponding properties (y_new) that were not used to fit
-    # the hull.
-    Xr = selector.score_samples(X, y)
+.. autoclass:: skmatter.sample_selection.DirectionalConvexHull
+   :members:
+   :undoc-members:
+   :inherited-members:

--- a/docs/src/utils.rst
+++ b/docs/src/utils.rst
@@ -33,4 +33,4 @@ for feature and sample selection.
 Random Partitioning with Overlaps
 #################################
 
-.. automodule:: skmatter.model_selection._split
+.. autofunction:: skmatter.model_selection.train_test_split

--- a/src/skmatter/decomposition/_pcovr.py
+++ b/src/skmatter/decomposition/_pcovr.py
@@ -55,6 +55,7 @@ class PCovR(_BasePCA, LinearModel):
     This can be done with the companion preprocessing classes, where
 
     >>> from skmatter.preprocessing import StandardFlexibleScaler as SFS
+    >>> import numpy as np
     >>>
     >>> # Set column_wise to True when the columns are relative to one another,
     >>> # False otherwise.

--- a/src/skmatter/feature_selection/_base.py
+++ b/src/skmatter/feature_selection/_base.py
@@ -50,9 +50,36 @@ class FPS(_FPS):
 
     n_selected_ : int
                   Counter tracking the number of selections that have been made
+
     X_selected_ : ndarray,
                   Matrix containing the selected features, for use in fitting
 
+    selected_idx_ : ndarray
+                  indices of selected samples
+
+    Examples
+    --------
+    >>> from skmatter.feature_selection import FPS
+    >>> import numpy as np
+    >>> selector = FPS(
+    ...     n_to_select=2,
+    ...     # int or 'random', default=0
+    ...     # Index of the first selection.
+    ...     # If ‘random’, picks a random value when fit starts.
+    ...     initialize=0,
+    ... )
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> selector.fit(X)
+    FPS(n_to_select=2)
+    >>> Xr = selector.transform(X)
+    >>> selector.selected_idx_
+    array([0, 1])
     """
 
     def __init__(
@@ -129,6 +156,30 @@ class PCovFPS(_PCovFPS):
     X_selected_ : ndarray,
                   Matrix containing the selected features, for use in fitting
 
+    Examples
+    --------
+    >>> from skmatter.feature_selection import PCovFPS
+    >>> import numpy as np
+    >>> selector = PCovFPS(
+    ...     n_to_select=2,
+    ...     # int or 'random', default=0
+    ...     # Index of the first selection.
+    ...     # If ‘random’, picks a random value when fit starts.
+    ...     initialize=0,
+    ... )
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> y = np.array([0.0, 0.0, 1.0])  # classes of each sample
+    >>> selector.fit(X, y)
+    PCovFPS(n_to_select=2)
+    >>> Xr = selector.transform(X)
+    >>> selector.selected_idx_
+    array([0, 1])
     """
 
     def __init__(
@@ -172,7 +223,6 @@ class CUR(_CUR):
     tolerance: float
          threshold below which scores will be considered 0, defaults to 1E-12
 
-
     n_to_select : int or float, default=None
         The number of selections to make. If `None`, half of the features are
         selected. If integer, the parameter is the absolute number of selections
@@ -202,6 +252,7 @@ class CUR(_CUR):
 
     random_state: int or RandomState instance, default=0
 
+
     Attributes
     ----------
 
@@ -210,9 +261,37 @@ class CUR(_CUR):
 
     n_selected_ : int
                   Counter tracking the number of selections that have been made
+
     X_selected_ : ndarray,
                   Matrix containing the selected features, for use in fitting
 
+    pi_ : ndarray (n_features),
+                  the importance score see :func:`_compute_pi`
+
+    selected_idx_ : ndarray
+                  indices of selected features
+
+    Examples
+    --------
+    >>> from skmatter.feature_selection import CUR
+    >>> import numpy as np
+    >>> selector = CUR(n_to_select=2, random_state=0)
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> selector.fit(X)
+    CUR(n_to_select=2)
+    >>> Xr = selector.transform(X)
+    >>> print(Xr.shape)
+    (3, 2)
+    >>> np.round(selector.pi_, 2)  # importance scole
+    array([0.  , 0.  , 0.05])
+    >>> selector.selected_idx_  # importance scole
+    array([1, 0])
     """
 
     def __init__(
@@ -296,17 +375,40 @@ class PCovCUR(_PCovCUR):
     ----------
 
     X_current_ : ndarray (n_samples, n_features)
-                  The original matrix orthogonalized by previous selections
+                The original matrix orthogonalized by previous selections
 
     y_current_ : ndarray (n_samples, n_properties)
                 The targets orthogonalized by a regression on
                 the previous selections.
 
     n_selected_ : int
-                  Counter tracking the number of selections that have been made
-    X_selected_ : ndarray,
-                  Matrix containing the selected features, for use in fitting
+                Counter tracking the number of selections that have been made
 
+    X_selected_ : ndarray,
+                Matrix containing the selected features, for use in fitting
+
+    Examples
+    --------
+    >>> from skmatter.feature_selection import PCovCUR
+    >>> import numpy as np
+    >>> selector = PCovCUR(n_to_select=2, mixing=0.5, random_state=0)
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> y = np.array([0.0, 0.0, 1.0])  # classes of each sample
+    >>> selector.fit(X, y)
+    PCovCUR(n_to_select=2)
+    >>> Xr = selector.transform(X)
+    >>> print(Xr.shape)
+    (3, 2)
+    >>> np.round(selector.pi_, 2)  # importance scole
+    array([0.  , 0.  , 0.05])
+    >>> selector.selected_idx_  # importance scole
+    array([1, 0])
     """
 
     def __init__(

--- a/src/skmatter/preprocessing/_data.py
+++ b/src/skmatter/preprocessing/_data.py
@@ -232,10 +232,11 @@ class KernelNormalizer(KernelCenterer):
     """Kernel centering method, similar to KernelCenterer,
     but with additional scaling and ability to pass a set of sample weights.
 
-    Let K(x, z) be a kernel defined by phi(x)^T phi(z), where phi is a
-    function mapping x to a Hilbert space. KernelNormalizer centers (i.e.,
-    normalize to have zero mean) the data without explicitly computing phi(x).
-    It is equivalent to centering and scaling phi(x) with
+    Let :math:`K(x, z)` be a kernel defined by :math:`\\phi(x)^T \\phi(z)`,
+    where :math:`\\phi` is a function mapping x to a Hilbert space.
+    KernelNormalizer centers (i.e., normalize to have zero mean) the data without
+    explicitly computing :math:`\\phi(x)`.
+    It is equivalent to centering and scaling :math:`\\phi(x)` with
     sklearn.preprocessing.StandardScaler(with_std=False).
 
     Parameters

--- a/src/skmatter/sample_selection/_base.py
+++ b/src/skmatter/sample_selection/_base.py
@@ -96,12 +96,39 @@ class FPS(_FPS):
 
     n_selected_ : int
                   Counter tracking the number of selections that have been made
+
     X_selected_ : ndarray,
                   Matrix containing the selected samples, for use in fitting
+
     y_selected_ : ndarray,
                   In sample selection, the matrix containing the selected targets, for
                   use in fitting
 
+    selected_idx_ : ndarray
+                  indices of selected samples
+
+    Examples
+    --------
+    >>> from skmatter.sample_selection import FPS
+    >>> import numpy as np
+    >>> selector = FPS(
+    ...     n_to_select=2,
+    ...     # int or 'random', default=0
+    ...     # Index of the first selection.
+    ...     # If ‘random’, picks a random value when fit starts.
+    ...     initialize=0,
+    ... )
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> selector.fit(X)
+    FPS(n_to_select=2)
+    >>> selector.selected_idx_
+    array([0, 2])
     """
 
     def __init__(
@@ -175,13 +202,40 @@ class PCovFPS(_PCovFPS):
 
     n_selected_ : int
                   Counter tracking the number of selections that have been made
+
     X_selected_ : ndarray,
                   Matrix containing the selected samples, for use in fitting
+
     y_selected_ : ndarray,
                   In sample selection, the matrix containing the selected targets, for
                   use in fitting
 
+    selected_idx_ : ndarray
+                  indices of selected samples
 
+    Examples
+    --------
+    >>> from skmatter.sample_selection import PCovFPS
+    >>> import numpy as np
+    >>> selector = PCovFPS(
+    ...     n_to_select=2,
+    ...     # int or 'random', default=0
+    ...     # Index of the first selection.
+    ...     # If ‘random’, picks a random value when fit starts.
+    ...     initialize=0,
+    ... )
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> y = np.array([0.0, 0.0, 1.0])  # classes of each sample
+    >>> selector.fit(X, y)
+    PCovFPS(n_to_select=2)
+    >>> selector.selected_idx_
+    array([0, 2])
     """
 
     def __init__(
@@ -210,63 +264,97 @@ class PCovFPS(_PCovFPS):
 
 class CUR(_CUR):
     """Transformer that performs Greedy Sample Selection by choosing samples
-     which maximize the magnitude of the left singular vectors, consistent with
-     classic CUR matrix decomposition.
+    which maximize the magnitude of the left singular vectors, consistent with
+    classic CUR matrix decomposition.
 
     Parameters
-     ----------
-     recompute_every : int
-                       number of steps after which to recompute the pi score
-                       defaults to 1, if 0 no re-computation is done
+    ----------
+    recompute_every : int
+                      number of steps after which to recompute the pi score
+                      defaults to 1, if 0 no re-computation is done
 
-     k : int
-         number of eigenvectors to compute the importance score with, defaults to 1
+    k : int
+        number of eigenvectors to compute the importance score with, defaults to 1
 
-     tolerance: float
-          threshold below which scores will be considered 0, defaults to 1E-12
+    tolerance: float
+         threshold below which scores will be considered 0, defaults to 1E-12
 
-     n_to_select : int or float, default=None
-         The number of selections to make. If `None`, half of the samples are
-         selected. If integer, the parameter is the absolute number of selections
-         to make. If float between 0 and 1, it is the fraction of the total dataset to
-         select. Stored in :py:attr:`self.n_to_select`.
+    n_to_select : int or float, default=None
+        The number of selections to make. If `None`, half of the samples are
+        selected. If integer, the parameter is the absolute number of selections
+        to make. If float between 0 and 1, it is the fraction of the total dataset to
+        select. Stored in :py:attr:`self.n_to_select`.
 
-     score_threshold : float, default=None
-         Threshold for the score. If `None` selection will continue until the
-         n_to_select is chosen. Otherwise will stop when the score falls below the
-         threshold. Stored in :py:attr:`self.score_threshold`.
+    score_threshold : float, default=None
+        Threshold for the score. If `None` selection will continue until the
+        n_to_select is chosen. Otherwise will stop when the score falls below the
+        threshold. Stored in :py:attr:`self.score_threshold`.
 
-     score_threshold_type : str, default="absolute"
-         How to interpret the ``score_threshold``. When "absolute", the score used by
-         the selector is compared to the threshold directly. When "relative", at each
-         iteration, the score used by the selector is compared proportionally to the
-         score of the first selection, i.e. the selector quits when
-         ``current_score / first_score < threshold``. Stored in
-         :py:attr:`self.score_threshold_type`.
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each
+        iteration, the score used by the selector is compared proportionally to the
+        score of the first selection, i.e. the selector quits when
+        ``current_score / first_score < threshold``. Stored in
+        :py:attr:`self.score_threshold_type`.
 
-     progress_bar: bool, default=False
-               option to use `tqdm <https://tqdm.github.io/>`_ progress bar to monitor
-               selections. Stored in :py:attr:`self.report_progress`.
+    progress_bar: bool, default=False
+              option to use `tqdm <https://tqdm.github.io/>`_ progress bar to monitor
+              selections. Stored in :py:attr:`self.report_progress`.
 
-     full : bool, default=False
-         In the case that all non-redundant selections are exhausted, choose
-         randomly from the remaining samples. Stored in :py:attr:`self.full`.
+    full : bool, default=False
+        In the case that all non-redundant selections are exhausted, choose
+        randomly from the remaining samples. Stored in :py:attr:`self.full`.
 
-     random_state: int or RandomState instance, default=0
+    random_state: int or RandomState instance, default=0
 
-     Attributes
-     ----------
+    Attributes
+    ----------
 
-     X_current_ : ndarray (n_samples, n_features)
-                   The original matrix orthogonalized by previous selections
+    X_current_ : ndarray (n_samples, n_features)
+                  The original matrix orthogonalized by previous selections
 
-     n_selected_ : int
-                   Counter tracking the number of selections that have been made
-     X_selected_ : ndarray,
-                   Matrix containing the selected samples, for use in fitting
-     y_selected_ : ndarray,
-                   In sample selection, the matrix containing the selected targets, for
-                   use in fitting
+    n_selected_ : int
+                  Counter tracking the number of selections that have been made
+
+    X_selected_ : ndarray,
+                  Matrix containing the selected samples, for use in fitting
+
+    y_selected_ : ndarray,
+                  In sample selection, the matrix containing the selected targets, for
+                  use in fitting
+
+    pi_ : ndarray (n_features),
+                  the importance score see :func:`_compute_pi`
+
+    selected_idx_ : ndarray
+                  indices of selected features
+
+    Examples
+    --------
+    >>> from skmatter.sample_selection import CUR
+    >>> import numpy as np
+    >>> selector = CUR(n_to_select=2, random_state=0)
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> np.random.seed(0)  # there is a source of randomness in it
+    >>> selector.fit(X)
+    CUR(n_to_select=2)
+    >>> np.round(selector.pi_, 2)  # importance scole
+    array([0., 1., 0.])
+    >>> selector.selected_idx_  # importance scole
+    array([2, 0])
+    >>> # selector.transform(X) cannot be used as sklearn API
+    >>> # restricts the change of sample size using transformers
+    >>> # So one has to do
+    >>> X[selector.selected_idx_]
+    array([[-0.03, -0.53,  0.08],
+           [ 0.12,  0.21,  0.02]])
 
     """
 
@@ -362,12 +450,45 @@ class PCovCUR(_PCovCUR):
 
     n_selected_ : int
                   Counter tracking the number of selections that have been made
+
     X_selected_ : ndarray,
                   Matrix containing the selected samples, for use in fitting
+
     y_selected_ : ndarray,
                   In sample selection, the matrix containing the selected targets, for
                   use in fitting
 
+    pi_ : ndarray (n_features),
+                  the importance score see :func:`_compute_pi`
+
+    selected_idx_ : ndarray
+                  indices of selected features
+
+    Examples
+    --------
+    >>> from skmatter.sample_selection import PCovCUR
+    >>> import numpy as np
+    >>> selector = PCovCUR(n_to_select=2, random_state=0)
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> y = np.array([0.0, 0.0, 1.0])  # classes of each sample
+    >>> selector.fit(X, y)
+    PCovCUR(n_to_select=2)
+    >>> np.round(selector.pi_, 2)  # importance scole
+    array([1., 0., 0.])
+    >>> selector.selected_idx_  # importance scole
+    array([2, 1])
+    >>> # selector.transform(X) cannot be used as sklearn API
+    >>> # restricts the change of sample size using transformers
+    >>> # So one has to do
+    >>> X[selector.selected_idx_]
+    array([[-0.03, -0.53,  0.08],
+           [-0.09,  0.32, -0.1 ]])
     """
 
     def __init__(
@@ -454,6 +575,34 @@ class DirectionalConvexHull:
     interpolator_high_dim_  : scipy.interpolate.interpnd.LinearNDInterpolator
                     Interpolator for the features in the high-
                     dimensional space
+
+    Examples
+    --------
+    >>> from skmatter.sample_selection import DirectionalConvexHull
+    >>> selector = DirectionalConvexHull(
+    ...     # Indices of columns of X to use for fitting
+    ...     # the convex hull
+    ...     low_dim_idx=[0, 1],
+    ... )
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...         [-0.41, 0.25, 0.34],
+    ...     ]
+    ... )
+    >>> y = np.array([0.1, 1.0, 0.2, 0.4])  # classes of each sample
+    >>> dch = selector.fit(X, y)
+    >>> # Get the distance to the convex hull for samples used to fit the
+    >>> # convex hull. This can also be called using other samples (X_new)
+    >>> # and corresponding properties (y_new) that were not used to fit
+    >>> # the hull. In this case they are alle one the conex hull so we
+    >>> # zeros
+    >>> np.allclose(dch.score_samples(X, y), [0.0, 0.0, 0.0, 0.0])
+    True
+
+
 
     References
     ----------

--- a/src/skmatter/sample_selection/_voronoi_fps.py
+++ b/src/skmatter/sample_selection/_voronoi_fps.py
@@ -54,6 +54,33 @@ class VoronoiFPS(GreedySelector):
         depends on many conditions, and it is determined "in situ" for optimal
         use of the algorithm. Determination is done with a few test calculations
         and memory operations.
+
+    Examples
+    --------
+    >>> from skmatter.sample_selection import VoronoiFPS
+    >>> selector = VoronoiFPS(
+    ...     n_to_select=2,
+    ...     progress_bar=True,
+    ...     score_threshold=1e-12,
+    ...     full=False,
+    ...     # n_trial_calculation used for calculation of full_fraction,
+    ...     # so you need to determine only one parameter
+    ...     n_trial_calculation=4,
+    ...     full_fraction=0.45,
+    ...     # int or 'random', default=0
+    ...     # Index of the first selection.
+    ...     # If ‘random’, picks a random value when fit starts.
+    ...     initialize=0,
+    ... )
+    >>> X = np.array(
+    ...     [
+    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
+    ...         [-0.09, 0.32, -0.10],
+    ...         [-0.03, -0.53, 0.08],
+    ...     ]
+    ... )
+    >>> selector.fit(X)
+    VoronoiFPS(full_fraction=0.45)
     """
 
     def __init__(

--- a/src/skmatter/utils/_orthogonalizers.py
+++ b/src/skmatter/utils/_orthogonalizers.py
@@ -100,7 +100,7 @@ def Y_feature_orthogonalizer(y, X, tol=1e-12, copy=True):
 
 def Y_sample_orthogonalizer(y, X, y_ref, X_ref, tol=1e-12, copy=True):
     """
-    Orthogonalizes a matrix of targets :math:`{\\mathbf{Y}}`given a reference feature
+    Orthogonalizes a matrix of targets :math:`{\\mathbf{Y}}` given a reference feature
     matrix :math:`{\\mathbf{X}_r}` and reference target matrix :math:`{\\mathbf{Y}_r}`:
 
     .. math::

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,9 @@ deps =
     -r docs/requirements.txt
 # The documentation runs "examples" to produce outputs via sphinx-gallery.
 extras = examples
-commands = sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
+commands =
+    sphinx-build {posargs:-E} -W -b doctest docs/src docs/build/doctest
+    sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 
 [flake8]
 max_line_length = 88


### PR DESCRIPTION
Most if it is rather straightforward. Still need to change some existing code blocks. But I also need to change the way the python API is embedded into the doc to include the doctest which is in the python code. See change
```rst
.. autoclass:: skmatter.feature_selection.CUR
   :members:
   :undoc-members:
   :inherited-members:
   :show-inheritance:
```
@rosecers Are you okay with this? Check out https://scikit-matter--201.org.readthedocs.build/en/201/selection.html#cur
Then I continue doing it for the other classes.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--201.org.readthedocs.build/en/201/

<!-- readthedocs-preview scikit-matter end -->