### PR TITLE
Fixing buggy sidebar sections for installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,11 @@ For details, tutorials, and examples, please have a look at our `documentation`_
 
 .. _`documentation`: https://scikit-matter.readthedocs.io
 
-.. marker-installation
 
 Installation
 ------------
+
+.. marker-installation-begin
 
 You can install *scikit-matter* either via pip using
 
@@ -30,6 +31,9 @@ or conda
 
 
 You can then `import skmatter` and use scikit-matter in your projects!
+
+.. marker-installation-end
+
 
 .. marker-issues
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -1,6 +1,12 @@
+Installation
+============
+
+Install using pip or conda
+--------------------------
+
 .. include:: ../../README.rst
-   :start-after: marker-installation
-   :end-before: marker-issues
+   :start-after: marker-installation-begin
+   :end-before: marker-installation-end
 
 Install from source
 -------------------


### PR DESCRIPTION
* The header "Installation" in the README.rst caused that the installation section was not shown correctly in the left sidebar in the doc, so we now exclude the header in the doc, and do a custom one

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--203.org.readthedocs.build/en/203/

<!-- readthedocs-preview scikit-matter end -->