### PR TITLE
Add random state to svd in _compute_pi function

### DIFF
--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -649,14 +649,15 @@ class _CUR(GreedySelector):
             :math:`\\pi` importance for the given samples or features
         """
 
+        svd_kwargs = dict(k=self.k, random_state=self.random_state)
         if self._axis == 0:
-            U, _, _ = scipy.sparse.linalg.svds(X, k=self.k, return_singular_vectors="u")
+            svd_kwargs["return_singular_vectors"] = "u"
+            U, _, _ = scipy.sparse.linalg.svds(X, **svd_kwargs)
             U = np.real(U)
             new_pi = (U[:, : self.k] ** 2.0).sum(axis=1)
         else:
-            _, _, Vt = scipy.sparse.linalg.svds(
-                X, k=self.k, return_singular_vectors="vh"
-            )
+            svd_kwargs["return_singular_vectors"] = "vh"
+            _, _, Vt = scipy.sparse.linalg.svds(X, **svd_kwargs)
             new_pi = (np.real(Vt) ** 2.0).sum(axis=0)
 
         return new_pi

--- a/src/skmatter/sample_selection/_base.py
+++ b/src/skmatter/sample_selection/_base.py
@@ -337,23 +337,24 @@ class CUR(_CUR):
     >>> selector = CUR(n_to_select=2, random_state=0)
     >>> X = np.array(
     ...     [
-    ...         [0.12, 0.21, 0.02],  # 3 samples, 3 features
-    ...         [-0.09, 0.32, -0.10],
-    ...         [-0.03, -0.53, 0.08],
+    ...         [0.12, 0.21, -0.11],  # 4 samples, 3 features
+    ...         [-0.09, 0.32, 0.51],
+    ...         [-0.03, 0.53, 0.14],
+    ...         [-0.83, -0.13, 0.82],
     ...     ]
     ... )
     >>> selector.fit(X)
     CUR(n_to_select=2)
-    >>> np.round(selector.pi_, 2)  # importance scole
-    array([0., 1., 0.])
-    >>> selector.selected_idx_  # importance scole
-    array([2, 0])
+    >>> np.round(selector.pi_, 2)  # importance score
+    array([0.01, 0.99, 0.  , 0.  ])
+    >>> selector.selected_idx_  # selected idx
+    array([3, 2])
     >>> # selector.transform(X) cannot be used as sklearn API
     >>> # restricts the change of sample size using transformers
     >>> # So one has to do
     >>> X[selector.selected_idx_]
-    array([[-0.03, -0.53,  0.08],
-           [ 0.12,  0.21,  0.02]])
+    array([[-0.83, -0.13,  0.82],
+           [-0.03,  0.53,  0.14]])
     """
 
     def __init__(

--- a/src/skmatter/sample_selection/_base.py
+++ b/src/skmatter/sample_selection/_base.py
@@ -342,7 +342,6 @@ class CUR(_CUR):
     ...         [-0.03, -0.53, 0.08],
     ...     ]
     ... )
-    >>> np.random.seed(0)  # there is a source of randomness in it
     >>> selector.fit(X)
     CUR(n_to_select=2)
     >>> np.round(selector.pi_, 2)  # importance scole


### PR DESCRIPTION
In one example we got nondeterministic behavior because of the random state in sparse linalg. We set the random state there now. The temporary fix to set np.random.seed is removed.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--210.org.readthedocs.build/en/210/

<!-- readthedocs-preview scikit-matter end -->