### PR TITLE
Rename RidgeRegression2FoldCV -> Ridge2FoldCV

### DIFF
--- a/docs/src/references/linear_models.rst
+++ b/docs/src/references/linear_models.rst
@@ -9,7 +9,7 @@ Orthogonal Regression
 Ridge Regression with Two-fold Cross Validation
 -----------------------------------------------
 
-.. autoclass:: skmatter.linear_model.RidgeRegression2FoldCV
+.. autoclass:: skmatter.linear_model.Ridge2FoldCV
 
 PCovR
 -----

--- a/examples/regression/Ridge2FoldCVRegularization.py
+++ b/examples/regression/Ridge2FoldCVRegularization.py
@@ -1,14 +1,14 @@
 # %%
 
 r"""
- RidgeRegression2FoldCV for data with low effective rank
+ Ridge2FoldCV for data with low effective rank
  =======================================================
  In this notebook we explain in more detail how
- :class:`skmatter.linear_model.RidgeRegression2FoldCV` speeds up the
+ :class:`skmatter.linear_model.Ridge2FoldCV` speeds up the
  cross-validation optimizing the regularitzation parameter :param alpha: and
  compare it with existing solution for that in scikit-learn
  :class:`slearn.linear_model.RidgeCV`.
- :class:`skmatter.linear_model.RidgeRegression2FoldCV` was designed to predict
+ :class:`skmatter.linear_model.Ridge2FoldCV` was designed to predict
  efficiently feature matrices, but it can be also useful for the prediction
  single targets.
 """
@@ -24,7 +24,7 @@ from sklearn.linear_model import RidgeCV
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import KFold, train_test_split
 
-from skmatter.linear_model import RidgeRegression2FoldCV
+from skmatter.linear_model import Ridge2FoldCV
 
 
 # %%
@@ -44,7 +44,7 @@ N_REPEAT_MICRO_BENCH = 5
 # efficient leave-one-out CV (LOO CV) for its ridge regression which avoids
 # these repeated computations [loocv]_. Because we needed an efficient ridge that works
 # in predicting  for the reconstruction measures in :py:mod:`skmatter.metrics`
-# we implemented with :class:`skmatter.linear_model.RidgeRegression2FoldCV` an
+# we implemented with :class:`skmatter.linear_model.Ridge2FoldCV` an
 # efficient 2-fold CV ridge regression that uses a singular value decomposition
 # (SVD) to reuse it for all regularization parameters :math:`\lambda`. Assuming
 # we have the standard regression problem optimizing the weight matrix in
@@ -75,7 +75,7 @@ N_REPEAT_MICRO_BENCH = 5
 #                 \textrm{ prediction of }\mathbf{Y}\textrm{ for fold 2}
 #      \end{align}
 #
-# The efficient 2-fold scheme in `RidgeRegression2FoldCV` reuses the matrices
+# The efficient 2-fold scheme in `Ridge2FoldCV` reuses the matrices
 #
 # .. math::
 #
@@ -107,11 +107,11 @@ alphas = np.geomspace(1e-12, 1e-1, 12)
 # 2 folds for train and validation split
 cv = KFold(n_splits=2, shuffle=True, random_state=SEED)
 
-skmatter_ridge_2foldcv_cutoff = RidgeRegression2FoldCV(
+skmatter_ridge_2foldcv_cutoff = Ridge2FoldCV(
     alphas=alphas, regularization_method="cutoff", cv=cv
 )
 
-skmatter_ridge_2foldcv_tikhonov = RidgeRegression2FoldCV(
+skmatter_ridge_2foldcv_tikhonov = Ridge2FoldCV(
     alphas=alphas, regularization_method="tikhonov", cv=cv
 )
 
@@ -318,13 +318,13 @@ alphas = np.geomspace(1e-8, 1e-1, 20)
 
 cv = KFold(n_splits=2, shuffle=True, random_state=SEED)
 
-skmatter_ridge_2foldcv_cutoff = RidgeRegression2FoldCV(
+skmatter_ridge_2foldcv_cutoff = Ridge2FoldCV(
     alphas=alphas,
     regularization_method="cutoff",
     cv=cv,
 )
 
-skmatter_ridge_2foldcv_tikhonov = RidgeRegression2FoldCV(
+skmatter_ridge_2foldcv_tikhonov = Ridge2FoldCV(
     alphas=alphas,
     regularization_method="tikhonov",
     cv=cv,

--- a/src/skmatter/linear_model/__init__.py
+++ b/src/skmatter/linear_model/__init__.py
@@ -1,4 +1,4 @@
 from ._base import OrthogonalRegression
-from ._ridge import RidgeRegression2FoldCV
+from ._ridge import Ridge2FoldCV
 
-__all__ = ["OrthogonalRegression", "RidgeRegression2FoldCV"]
+__all__ = ["OrthogonalRegression", "Ridge2FoldCV"]

--- a/src/skmatter/linear_model/_ridge.py
+++ b/src/skmatter/linear_model/_ridge.py
@@ -7,7 +7,7 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 
 
-class RidgeRegression2FoldCV(BaseEstimator, MultiOutputMixin, RegressorMixin):
+class Ridge2FoldCV(BaseEstimator, MultiOutputMixin, RegressorMixin):
     r"""Ridge regression with an efficient 2-fold cross-validation method using the SVD
     solver.
 

--- a/src/skmatter/metrics/__init__.py
+++ b/src/skmatter/metrics/__init__.py
@@ -10,7 +10,7 @@ is contained in `F`. All methods are implemented as the root mean-square error
 for the regression of the feature matrix `X_F'` (or sometimes called `Y` in the
 doc) from `X_F` (or sometimes called `X` in the doc) for transformations with
 different constraints (linear, orthogonal, locally-linear). By default a custom
-2-fold cross-validation :py:class:`skosmo.linear_model.RidgeRegression2FoldCV`
+2-fold cross-validation :py:class:`skosmo.linear_model.Ridge2FoldCV`
 is used to ensure the generalization of the transformation and efficiency of the
 computation, since we deal with a multi-target regression problem. Methods were
 applied to compare different forms of featurizations through different

--- a/src/skmatter/metrics/_reconstruction_measures.py
+++ b/src/skmatter/metrics/_reconstruction_measures.py
@@ -1,7 +1,7 @@
 import numpy as np
 from joblib import Parallel, delayed
 
-from ..linear_model import OrthogonalRegression, RidgeRegression2FoldCV
+from ..linear_model import OrthogonalRegression, Ridge2FoldCV
 from ..model_selection import train_test_split
 from ..preprocessing import StandardFlexibleScaler
 
@@ -597,7 +597,7 @@ def check_global_reconstruction_measures_input(
         scaler = StandardFlexibleScaler()
 
     if estimator is None:
-        estimator = RidgeRegression2FoldCV(
+        estimator = Ridge2FoldCV(
             alphas=np.geomspace(1e-9, 0.9, 20),
             alpha_type="relative",
             regularization_method="cutoff",

--- a/tests/test_check_estimators.py
+++ b/tests/test_check_estimators.py
@@ -5,7 +5,7 @@ from skmatter.feature_selection import CUR as fCUR
 from skmatter.feature_selection import FPS as fFPS
 from skmatter.feature_selection import PCovCUR as fPCovCUR
 from skmatter.feature_selection import PCovFPS as fPCovFPS
-from skmatter.linear_model import RidgeRegression2FoldCV  # OrthogonalRegression,
+from skmatter.linear_model import Ridge2FoldCV  # OrthogonalRegression,
 from skmatter.preprocessing import KernelNormalizer, StandardFlexibleScaler
 
 
@@ -17,7 +17,7 @@ from skmatter.preprocessing import KernelNormalizer, StandardFlexibleScaler
         fFPS(),
         fPCovCUR(),
         fPCovFPS(),
-        RidgeRegression2FoldCV(),
+        Ridge2FoldCV(),
         KernelNormalizer(),
         StandardFlexibleScaler(),
     ]

--- a/tests/test_linear_model.py
+++ b/tests/test_linear_model.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 from sklearn.datasets import load_iris
 from sklearn.utils import check_random_state, extmath
 
-from skmatter.linear_model import OrthogonalRegression, RidgeRegression2FoldCV
+from skmatter.linear_model import OrthogonalRegression, Ridge2FoldCV
 
 
 class BaseTests(unittest.TestCase):
@@ -108,37 +108,35 @@ class RidgeTests(unittest.TestCase):
         cls.ridge_regressions = []
 
     def test_ridge_regression_2fold_regularization_method_raise_error(self):
-        # tests if wrong regularization_method in RidgeRegression2FoldCV raises error
+        # tests if wrong regularization_method in Ridge2FoldCV raises error
         with self.assertRaises(ValueError):
-            RidgeRegression2FoldCV(
+            Ridge2FoldCV(
                 regularization_method="dummy",
             ).fit(self.features_small, self.features_small)
 
     def test_ridge_regression_2fold_alpha_type_raise_error(self):
-        # tests if wrong alpha type in RidgeRegression2FoldCV raises error
+        # tests if wrong alpha type in Ridge2FoldCV raises error
         with self.assertRaises(ValueError):
-            RidgeRegression2FoldCV(
+            Ridge2FoldCV(
                 alpha_type="dummy",
             ).fit(self.features_small, self.features_small)
 
     def test_ridge_regression_2fold_relative_alpha_type_raise_error(self):
         # tests if an error is raised if alpha not in [0,1)
         with self.assertRaises(ValueError):
-            RidgeRegression2FoldCV(alphas=[1], alpha_type="relative").fit(
+            Ridge2FoldCV(alphas=[1], alpha_type="relative").fit(
                 self.features_small, self.features_small
             )
 
         with self.assertRaises(ValueError):
-            RidgeRegression2FoldCV(alphas=[-0.1], alpha_type="relative").fit(
+            Ridge2FoldCV(alphas=[-0.1], alpha_type="relative").fit(
                 self.features_small, self.features_small
             )
 
     def test_ridge_regression_2fold_iterable_cv(self):
         # tests if we can use iterable as cv parameter
         cv = [([0, 1, 2, 3], [4, 5, 6])]
-        RidgeRegression2FoldCV(alphas=[1], cv=cv).fit(
-            self.features_small, self.features_small
-        )
+        Ridge2FoldCV(alphas=[1], cv=cv).fit(self.features_small, self.features_small)
 
     ridge_parameters = [
         ["absolute_tikhonov", "absolute", "tikhonov"],
@@ -151,11 +149,11 @@ class RidgeTests(unittest.TestCase):
     def test_ridge_regression_2fold_cv_small_to_small(
         self, name, alpha_type, regularization_method
     ):
-        # tests if RidgeRegression2FoldCV can predict small features using small
+        # tests if Ridge2FoldCV can predict small features using small
         # features with use_orthogonal_projector False
         err = np.linalg.norm(
             self.features_small
-            - RidgeRegression2FoldCV(
+            - Ridge2FoldCV(
                 alphas=self.alphas,
                 alpha_type=alpha_type,
                 regularization_method=regularization_method,
@@ -169,7 +167,7 @@ class RidgeTests(unittest.TestCase):
 
     @parameterized.expand(ridge_parameters)
     def test_ridge_regression_2fold_cv_small_to_large(
-        # tests if RidgeRegression2FoldCV can predict large features using small
+        # tests if Ridge2FoldCV can predict large features using small
         # features with use_orthogonal_projector False
         self,
         name,
@@ -178,7 +176,7 @@ class RidgeTests(unittest.TestCase):
     ):
         err = np.linalg.norm(
             self.features_large
-            - RidgeRegression2FoldCV(
+            - Ridge2FoldCV(
                 alphas=self.alphas,
                 alpha_type=alpha_type,
                 regularization_method=regularization_method,
@@ -196,7 +194,7 @@ class RidgeTests(unittest.TestCase):
         self, name, alpha_type, regularization_method
     ):
         # tests if the regularization in the CV split of
-        # RidgeRegression2FoldCV does effect the results
+        # Ridge2FoldCV does effect the results
 
         # regularization parameters are chosen to match the singular values o
         # the features, thus each regularization parameter affects the minimized
@@ -207,8 +205,8 @@ class RidgeTests(unittest.TestCase):
         if alpha_type == "relative":
             alphas = singular_values[1:][::-1] / singular_values[0]
 
-        # tests if RidgeRegression2FoldCV does do regularization correct
-        ridge = RidgeRegression2FoldCV(
+        # tests if Ridge2FoldCV does do regularization correct
+        ridge = Ridge2FoldCV(
             alphas=alphas,
             alpha_type=alpha_type,
             regularization_method=regularization_method,


### PR DESCRIPTION
Since we will make a new minor version, we can break the API a bit and I wanted to rename the class to be more consistent with scikit-learn naming scheme (Ridge and RidgeCV). Also much shorter name

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--211.org.readthedocs.build/en/211/

<!-- readthedocs-preview scikit-matter end -->