### PR TITLE
Making the trace component of SparseKernelNormalizer more memory-frie…

### DIFF
--- a/src/skmatter/preprocessing/_data.py
+++ b/src/skmatter/preprocessing/_data.py
@@ -524,7 +524,11 @@ class SparseKernelCenterer(TransformerMixin):
         if self.with_trace:
             Knm_centered = Knm - self.K_fit_rows_
 
-            Khat = Knm_centered @ np.linalg.pinv(Kmm, self.rcond) @ Knm_centered.T
+            # The following is more correctly written as Knm @ Kmm^{-1} @ Knm.T
+            # but has been changed to Knm.T @ Knm @ Kmm^{-1} to avoid the memory
+            # overload often caused by storing n x n matrices. This is fine
+            # for the following trace, but should not be used for other operations.
+            Khat = Knm_centered.T @ Knm_centered @ np.linalg.pinv(Kmm, self.rcond)
 
             self.scale_ = np.sqrt(np.trace(Khat) / Knm.shape[0])
         else:


### PR DESCRIPTION
…ndly

Using the equality of traces under cyclic products, I've modified the sparse kernel
normalizer to be less memory-hungry. Had a few issues using this and having RAM crash


Contributor (creator of PR) checklist
-------------------------------------
 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

For Reviewer
------------
 - [ ] CHANGELOG updated if important change?
