### PR TITLE
Fix markup of import in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ or conda
     conda install -c conda-forge skmatter
 
 
-You can then `import skmatter` and use scikit-matter in your projects!
+You can then ``import skmatter`` and use scikit-matter in your projects!
 
 .. marker-ci-tests
 


### PR DESCRIPTION
import skmatter is shown as actual code block and not in italic.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--220.org.readthedocs.build/en/220/

<!-- readthedocs-preview scikit-matter end -->