### PR TITLE
Sparse KDE

### DIFF
--- a/src/skmatter/metrics/__init__.py
+++ b/src/skmatter/metrics/__init__.py
@@ -57,7 +57,7 @@ from ._prediction_rigidities import (
 
 from .pairwise import (
     pairwise_euclidean_distances,
-    pairwise_mahalanobis_distance,
+    pairwise_mahalanobis_distances,
 )
 
 __all__ = [
@@ -72,5 +72,5 @@ __all__ = [
     "local_prediction_rigidity",
     "componentwise_prediction_rigidity",
     "pairwise_euclidean_distances",
-    "pairwise_mahalanobis_distance",
+    "pairwise_mahalanobis_distances",
 ]

--- a/src/skmatter/metrics/__init__.py
+++ b/src/skmatter/metrics/__init__.py
@@ -57,6 +57,7 @@ from ._prediction_rigidities import (
 
 from .pairwise import (
     pairwise_euclidean_distances,
+    pairwise_mahalanobis_distance,
 )
 
 __all__ = [
@@ -71,4 +72,5 @@ __all__ = [
     "local_prediction_rigidity",
     "componentwise_prediction_rigidity",
     "pairwise_euclidean_distances",
+    "pairwise_mahalanobis_distance",
 ]

--- a/src/skmatter/metrics/__init__.py
+++ b/src/skmatter/metrics/__init__.py
@@ -55,6 +55,10 @@ from ._prediction_rigidities import (
     componentwise_prediction_rigidity,
 )
 
+from .pairwise import (
+    pairwise_euclidean_distances,
+)
+
 __all__ = [
     "pointwise_global_reconstruction_error",
     "global_reconstruction_error",
@@ -66,4 +70,5 @@ __all__ = [
     "check_local_reconstruction_measures_input",
     "local_prediction_rigidity",
     "componentwise_prediction_rigidity",
+    "pairwise_euclidean_distances",
 ]

--- a/src/skmatter/metrics/pairwise.py
+++ b/src/skmatter/metrics/pairwise.py
@@ -56,6 +56,10 @@ def pairwise_euclidean_distances(
         ``(X**2).sum(axis=1)``)
         May be ignored in some cases, see the note below.
 
+    cell : array-like of shape (n_features,), default=None
+        The cell size for periodic boundary conditions.
+        None for non-periodic boundary conditions.
+
     Returns
     -------
     distances : ndarray of shape (n_samples_X, n_samples_Y)
@@ -139,16 +143,23 @@ def pairwise_mahalanobis_distances(
     """
     Calculate the pairwise Mahalanobis distance between two arrays.
 
-    Args:
-        x (np.ndarray): The first input array.
-        y (np.ndarray): The second input array.
-        cov_inv (np.ndarray): The inverse covariance matrix.
-        cell (Union[np.ndarray, None]): The cell size for periodic boundary conditions.
-        squared (bool): Whether to return the squared distance.
+    Parameters:
+        x : np.ndarray
+            The first input array.
+        y : np.ndarray
+            The second input array.
+        cov_inv : np.ndarray
+            The inverse covariance matrix.
+        cell : np.ndarray, optinal
+            The cell size for periodic boundary conditions.
+        squared : bool
+            Whether to return the squared distance.
 
-    Returns:
-        np.ndarray: The pairwise Mahalanobis distance between the two input arrays,
-            of shape (cov_inv.shape[0], x.shape[0], y.shape[0]).
+    Returns
+    -------
+    np.ndarray
+        The pairwise Mahalanobis distance between the two input arrays,
+        of shape `(cov_inv.shape[0], x.shape[0], y.shape[0])`.
     """
 
     def _mahalanobis_preprocess(cov_inv: np.ndarray):

--- a/src/skmatter/metrics/pairwise.py
+++ b/src/skmatter/metrics/pairwise.py
@@ -1,10 +1,10 @@
 from typing import Union
-import numpy as np
 
+import numpy as np
 from sklearn.metrics.pairwise import (
-    check_pairwise_arrays,
-    check_array,
     _euclidean_distances,
+    check_array,
+    check_pairwise_arrays,
 )
 
 

--- a/src/skmatter/metrics/pairwise.py
+++ b/src/skmatter/metrics/pairwise.py
@@ -129,7 +129,7 @@ def _periodic_euclidean_distances(X, Y=None, *, squared=False, cell=None):
     return distance
 
 
-def pairwise_mahalanobis_distance(
+def pairwise_mahalanobis_distances(
     X: np.ndarray,
     Y: np.ndarray,
     cov_inv: np.ndarray,

--- a/src/skmatter/neighbors/__init__.py
+++ b/src/skmatter/neighbors/__init__.py
@@ -1,6 +1,3 @@
 from ._sparsekde import SparseKDE, covariance, effdim, oas
 
-__all__ = ["SparseKDE",
-           "covariance",
-           "effdim",
-           "oas"]
+__all__ = ["SparseKDE", "covariance", "effdim", "oas"]

--- a/src/skmatter/neighbors/__init__.py
+++ b/src/skmatter/neighbors/__init__.py
@@ -1,3 +1,6 @@
-from ._sparsekde import SparseKDE
+from ._sparsekde import SparseKDE, covariance, effdim, oas
 
-__all__ = ["SparseKDE"]
+__all__ = ["SparseKDE",
+           "covariance",
+           "effdim",
+           "oas"]

--- a/src/skmatter/neighbors/_sparsekde.py
+++ b/src/skmatter/neighbors/_sparsekde.py
@@ -7,6 +7,7 @@ from rich.progress import track
 
 from ..metrics.pairwise import pairwise_euclidean_distances
 
+
 class SparseKDE(BaseEstimator):
     """A sparse implementation of the Kernel Density Estimation.
 
@@ -26,26 +27,42 @@ class SparseKDE(BaseEstimator):
         Additional parameters to be passed to the use of
         metric.  i.e. the cell dimension for `periodic_euclidean`
     """
-    def __init__(self, kernel, metric, metric_params,
-                 descriptors: np.ndarray, weights: np.ndarray,
-                 qs:float = 1., gs:int = -1, thrpcl: float=0.,
-                 fspread:float = -1., fpoints:float = 0.15):
+
+    def __init__(
+        self,
+        kernel,
+        metric,
+        metric_params,
+        descriptors: np.ndarray,
+        weights: np.ndarray,
+        qs: float = 1.0,
+        gs: int = -1,
+        thrpcl: float = 0.0,
+        fspread: float = -1.0,
+        fpoints: float = 0.15,
+        nmsopt: int = 0,
+    ):
         self.kernel = kernel
         self.metric = metric
         self.metric_params = metric_params
-        self.cell = metric_params['cell'] if 'cell' in metric_params else None
+        self.cell = metric_params["cell"] if "cell" in metric_params else None
         self.descriptors = descriptors
-        self.weight = weights if weights is not None else np.ones(len(descriptors)) / len(descriptors)
+        self.weight = (
+            weights
+            if weights is not None
+            else np.ones(len(descriptors)) / len(descriptors)
+        )
         self.nsamples = len(descriptors)
         self.qs = qs
         self.gs = gs
         self.thrpcl = thrpcl
         self.fspread = fspread
         self.fpoints = fpoints
+        self.nmsopt = nmsopt
         self.kdecut2 = None
 
         if self.fspread > 0:
-            self.fpoints = -1.
+            self.fpoints = -1.0
 
     def fit(self, X, y=None, sample_weight=None, igrid=None):
         """Fit the Kernel Density model on the data.
@@ -81,15 +98,21 @@ class SparseKDE(BaseEstimator):
         grid_dist_mat = pairwise_euclidean_distances(X, X, squared=True, cell=self.cell)
         np.fill_diagonal(grid_dist_mat, np.inf)
         min_grid_dist = np.min(grid_dist_mat, axis=1)
-        grid_npoints, grid_neighbour, sample_labels_, sample_weight = self._assign_descriptors_to_grids(X)
-        h_invs, normkernels, qscut2 = self._computes_localization(X, sample_weight, min_grid_dist)
-        probs = self._computes_kernel_density_estimation(X, sample_weight, h_invs, normkernels, \
-                                                         igrid, grid_neighbour)
+        grid_npoints, grid_neighbour, sample_labels_, sample_weight = (
+            self._assign_descriptors_to_grids(X)
+        )
+        h_invs, normkernels, qscut2 = self._computes_localization(
+            X, sample_weight, min_grid_dist
+        )
+        probs = self._computes_kernel_density_estimation(
+            X, sample_weight, h_invs, normkernels, igrid, grid_neighbour
+        )
+        normpks = logsumexp(np.ones(grid_dist_mat.shape[0]), probs, 1)
         cluster_centers, idxroot = quick_shift(
-            X, probs, grid_dist_mat, qscut2, self.gs, self.cell, self.thrpcl)
+            X, probs, grid_dist_mat, qscut2, normpks, self.gs, self.cell, self.thrpcl
+        )
 
-        return idxroot
-
+        return self.generate_probability_model(X, sample_labels_, cluster_centers, h_invs, normkernels, probs, idxroot, normpks)
 
     def score_samples(self, X):
         """Compute the log-likelihood of each sample under the model.
@@ -164,101 +187,131 @@ class SparseKDE(BaseEstimator):
 
         return grid_npoints, grid_neighbour, labels, assigner.grid_weight
 
-    def _computes_localization(self, X, sample_weights: np.ndarray, mindist: np.ndarray):
+    def _computes_localization(
+        self, X, sample_weights: np.ndarray, mindist: np.ndarray
+    ):
 
         cov = covariance(X, sample_weights, self.cell)
 
         if self.cell is not None:
-            tune = sum(self.cell ** 2)
+            tune = sum(self.cell**2)
         else:
             tune = np.trace(cov)
 
         sigma2 = np.full(len(X), tune, dtype=float)
         # initialize the localization based on fraction of data spread
         if self.fspread > 0:
-            sigma2 *= self.fspread ** 2
-        flocal, normkernels, qscut2, h_tr_normed = \
-            np.zeros(len(X)), np.zeros(len(X)), np.zeros(len(X)), np.zeros(len(X))
+            sigma2 *= self.fspread**2
+        flocal, normkernels, qscut2, h_tr_normed = (
+            np.zeros(len(X)),
+            np.zeros(len(X)),
+            np.zeros(len(X)),
+            np.zeros(len(X)),
+        )
         h_invs = np.zeros((len(X), X.shape[1], X.shape[1]))
 
-        for i in track(range(len(X)), description='Estimating kernel density bandwidths'):
-            wlocal, flocal[i] = local_population(self.cell, X, X[i],
-                                                 sample_weights, sigma2[i])
+        for i in track(
+            range(len(X)), description="Estimating kernel density bandwidths"
+        ):
+            wlocal, flocal[i] = local_population(
+                self.cell, X, X[i], sample_weights, sigma2[i]
+            )
             if self.fpoints > 0:
-                sigma2, flocal, wlocal = \
-                    self._localization_based_on_fraction_of_points(
-                        X, sample_weights, sigma2, flocal, i, 1 / self.nsamples, tune)
+                sigma2, flocal, wlocal = self._localization_based_on_fraction_of_points(
+                    X, sample_weights, sigma2, flocal, i, 1 / self.nsamples, tune
+                )
             elif sigma2[i] < flocal[i]:
-                sigma2, flocal, wlocal = \
-                    self._localization_based_on_fraction_of_spread(X, sample_weights, sigma2, flocal, i, mindist)
-            h_invs[i], normkernels[i], qscut2[i], h_tr_normed[i] = \
-                self._bandwidth_estimation_from_localization(X, sample_weights, wlocal, flocal, i)
+                sigma2, flocal, wlocal = self._localization_based_on_fraction_of_spread(
+                    X, sample_weights, sigma2, flocal, i, mindist
+                )
+            h_invs[i], normkernels[i], qscut2[i], h_tr_normed[i] = (
+                self._bandwidth_estimation_from_localization(
+                    X, sample_weights, wlocal, flocal, i
+                )
+            )
 
-        qscut2 *= self.qs ** 2
+        qscut2 *= self.qs**2
 
         return h_invs, normkernels, qscut2
 
-    def _localization_based_on_fraction_of_points(self, X, sample_weights, sigma2, flocal, idx, delta, tune):
-        """Used in cases where one expects clusterswith very different spreads, 
+    def _localization_based_on_fraction_of_points(
+        self, X, sample_weights, sigma2, flocal, idx, delta, tune
+    ):
+        """Used in cases where one expects clusterswith very different spreads,
         but similar populations"""
 
         lim = self.fpoints
         if lim <= sample_weights[idx]:
             lim = sample_weights[idx] + delta
-            warnings.warn(" Warning: localization smaller than voronoi,"
-                          " increase grid size (meanwhile adjusted localization)!")
+            warnings.warn(
+                " Warning: localization smaller than voronoi,"
+                " increase grid size (meanwhile adjusted localization)!"
+            )
         while flocal[idx] < lim:
             sigma2[idx] += tune
-            wlocal, flocal[idx] = local_population(self.cell, X, X[idx],
-                                                   sample_weights, sigma2[idx])
+            wlocal, flocal[idx] = local_population(
+                self.cell, X, X[idx], sample_weights, sigma2[idx]
+            )
         j = 1
         while True:
             if flocal[idx] > lim:
-                sigma2[idx] -= tune / 2 ** j
+                sigma2[idx] -= tune / 2**j
             else:
-                sigma2[idx] += tune / 2 ** j
-            wlocal, flocal[idx] = local_population(self.cell, X, X[idx],
-                                                   sample_weights, sigma2[idx])
+                sigma2[idx] += tune / 2**j
+            wlocal, flocal[idx] = local_population(
+                self.cell, X, X[idx], sample_weights, sigma2[idx]
+            )
             if abs(flocal[idx] - lim) < delta:
                 break
             j += 1
 
         return sigma2, flocal, wlocal
 
-    def _localization_based_on_fraction_of_spread(self, X, sample_weights, sigma2, flocal, idx, mindist):
+    def _localization_based_on_fraction_of_spread(
+        self, X, sample_weights, sigma2, flocal, idx, mindist
+    ):
 
         sigma2[idx] = mindist[idx]
-        wlocal, flocal[idx] = local_population(self.cell, self.descriptors, X,
-                                               sample_weights, sigma2[idx])
+        wlocal, flocal[idx] = local_population(
+            self.cell, self.descriptors, X, sample_weights, sigma2[idx]
+        )
 
         return sigma2, flocal, wlocal
 
-    def _bandwidth_estimation_from_localization(self, X, sample_weights, wlocal, flocal, idx):
+    def _bandwidth_estimation_from_localization(
+        self, X, sample_weights, wlocal, flocal, idx
+    ):
 
         cov_i = covariance(X, wlocal, self.cell)
         nlocal = flocal[idx] * self.nsamples
         local_dimension = effdim(cov_i)
         cov_i = oas(cov_i, nlocal, X.shape[1])
         # localized version of Silverman's rule
-        h = (4. / nlocal / (local_dimension + 2.)) ** (2. / (local_dimension + 4.)) * cov_i
+        h = (4.0 / nlocal / (local_dimension + 2.0)) ** (
+            2.0 / (local_dimension + 4.0)
+        ) * cov_i
         h_tr_normed = np.trace(h) / h.shape[0]
         h_inv = np.linalg.inv(h)
         _, logdet_h = np.linalg.slogdet(h)
         normkernel = X.shape[1] * np.log(2 * np.pi) + logdet_h
         qscut2 = np.trace(cov_i)
 
-        return  h_inv, normkernel, qscut2, h_tr_normed
+        return h_inv, normkernel, qscut2, h_tr_normed
 
-    def _computes_kernel_density_estimation(self,
-                                            X: np.ndarray,
-                                            sample_weights: np.ndarray,
-                                            h_inv: np.ndarray,
-                                            normkernel: np.ndarray,
-                                            igrid: np.ndarray,
-                                            neighbour: dict):
+    def _computes_kernel_density_estimation(
+        self,
+        X: np.ndarray,
+        sample_weights: np.ndarray,
+        h_inv: np.ndarray,
+        normkernel: np.ndarray,
+        igrid: np.ndarray,
+        neighbour: dict,
+    ):
 
         prob = np.full(len(X), -np.inf)
-        for i in track(range(len(X)), description='Computing kernel density on reference points'):
+        for i in track(
+            range(len(X)), description="Computing kernel density on reference points"
+        ):
             dummd1s = mahalanobis(self.cell, X, X[i], h_inv)
             for j, dummd1 in enumerate(dummd1s):
                 if dummd1 > self.kdecut2:
@@ -266,15 +319,157 @@ class SparseKDE(BaseEstimator):
                     prob[i] = _update_prob(prob[i], lnk)
                 else:
                     neighbours = neighbour[j][neighbour[j] != igrid[i]]
-                    dummd1s = mahalanobis(self.cell, self.descriptors[neighbours],
-                                          X[i], h_inv[j])
-                    lnks = -0.5 * (normkernel[j] + dummd1s) + np.log(self.weight[neighbours])
+                    dummd1s = mahalanobis(
+                        self.cell, self.descriptors[neighbours], X[i], h_inv[j]
+                    )
+                    lnks = -0.5 * (normkernel[j] + dummd1s) + np.log(
+                        self.weight[neighbours]
+                    )
                     prob[i] = _update_probs(prob[i], lnks)
 
         prob -= np.log(np.sum(sample_weights))
 
         return prob
 
+    def generate_probability_model(
+        self,
+        X: np.ndarray,
+        sample_labels: np.ndarray,
+        cluster_centers: np.ndarray,
+        h_invs: np.ndarray,
+        normkernels: np.ndarray,
+        probs: np.ndarray,
+        idxroot: np.ndarray,
+        normpks: float,
+    ):
+        """
+        Generates a probability model based on the given inputs.
+
+        Parameters:
+            None
+
+        Returns:
+            None
+        """
+
+        dimension = X.shape[1]
+        cluster_mean = np.zeros((len(cluster_centers), dimension), dtype=float)
+        cluster_cov = np.zeros(
+            (len(cluster_centers), dimension, dimension), dtype=float
+        )
+        cluster_weight = np.zeros(len(cluster_centers), dtype=float)
+        center_idx = np.unique(idxroot)
+
+        for k in range(len(cluster_centers)):
+            cluster_mean[k] = X[center_idx[k]]
+            cluster_weight[k] = np.exp(
+                logsumexp(idxroot, probs, center_idx[k]) - normpks
+            )
+            for _ in range(self.nmsopt):
+                msmu = np.zeros(dimension, dtype=float)
+                tmppks = -np.inf
+                for i, x in enumerate(X):
+                    dummd1 = mahalanobis(
+                        self.cell, x, X[center_idx[k]], h_invs[center_idx[k]]
+                    )
+                    msw = -0.5 * (normkernels[center_idx[k]] + dummd1) + probs[i]
+                    tmpmsmu = rij(self.cell, x, X[center_idx[k]])
+                    msmu += np.exp(msw) * tmpmsmu
+                tmppks = _update_prob(tmppks, msw)
+                cluster_mean[k] += msmu / np.exp(tmppks)
+            cluster_cov[k] = self._update_cluster_cov(X, k, sample_labels, probs, idxroot, center_idx)
+
+        return cluster_weight, cluster_mean, cluster_cov
+
+    def _update_cluster_cov(
+        self,
+        X: np.ndarray,
+        k: int,
+        sample_labels: np.ndarray,
+        probs: np.ndarray,
+        idxroot: np.ndarray,
+        center_idx: np.ndarray,
+    ):
+
+        if self.cell is not None:
+            cov = self._get_lcov_clusterp(
+                len(X), self.nsamples, X, idxroot, center_idx[k], probs, self.cell
+            )
+            if np.sum(idxroot == center_idx[k]) == 1:
+                cov = self._get_lcov_clusterp(
+                    self.nsamples,
+                    self.nsamples,
+                    self.descriptors,
+                    sample_labels,
+                    center_idx[k],
+                    self.weight,
+                    self.cell,
+                )
+                print("Warning: single point cluster!")
+        else:
+            cov = self._get_lcov_cluster(len(X), X, idxroot, center_idx[k], probs, self.cell)
+            if np.sum(idxroot == center_idx[k]) == 1:
+                cov = self._get_lcov_cluster(
+                    self.nsamples,
+                    self.descriptors,
+                    sample_labels,
+                    center_idx[k],
+                    self.weight,
+                    self.cell,
+                )
+                print("Warning: single point cluster!")
+            cov = oas(
+                cov,
+                logsumexp(idxroot, probs, center_idx[k]) * self.nsamples,
+                X.shape[1],
+            )
+
+        return cov
+
+    def _get_lcov_cluster(
+        self,
+        N: int,
+        x: np.ndarray,
+        clroots: np.ndarray,
+        idcl: int,
+        probs: np.ndarray,
+        cell: np.ndarray,
+    ):
+
+        ww = np.zeros(N)
+        normww = logsumexp(clroots, probs, idcl)
+        ww[clroots == idcl] = np.exp(probs[clroots == idcl] - normww)
+        cov = covariance(x, ww, cell)
+
+        return cov
+
+    def _get_lcov_clusterp(
+        self,
+        N: int,
+        Ntot: int,
+        x: np.ndarray,
+        clroots: np.ndarray,
+        idcl: int,
+        probs: np.ndarray,
+        cell: np.ndarray,
+    ):
+
+        ww = np.zeros(N)
+        totnormp = logsumexp(np.zeros(N), probs, 0)
+        cov = np.zeros((x.shape[1], x.shape[1]), dtype=float)
+        xx = np.zeros(x.shape, dtype=float)
+        ww[clroots == idcl] = np.exp(probs[clroots == idcl] - totnormp)
+        ww *= Ntot
+        nlk = np.sum(ww)
+        for i in range(x.shape[1]):
+            xx[:, i] = x[:, i] - np.round(x[:, i] / cell[i]) * cell[i]
+            r2 = (np.sum(ww * np.cos(xx[:, i])) / nlk) ** 2 + (
+                np.sum(ww * np.sin(xx[:, i])) / nlk
+            ) ** 2
+            re2 = (nlk / (nlk - 1)) * (r2 - (1 / nlk))
+            cov[i, i] = 1 / (np.sqrt(re2) * (2 - re2) / (1 - re2))
+
+        return cov
 
 
 def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
@@ -308,10 +503,12 @@ def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
         xm = np.average(X, axis=0, weights=sample_weights / totw)
     else:
         for i in range(dimension):
-            sumsin = np.sum(sample_weights * np.sin(X[:, i]) *\
-                            (2 * np.pi) / cell[i]) / totw
-            sumcos = np.sum(sample_weights * np.cos(X[:, i]) *\
-                            (2 * np.pi) / cell[i]) / totw
+            sumsin = (
+                np.sum(sample_weights * np.sin(X[:, i]) * (2 * np.pi) / cell[i]) / totw
+            )
+            sumcos = (
+                np.sum(sample_weights * np.cos(X[:, i]) * (2 * np.pi) / cell[i]) / totw
+            )
             xm[i] = np.arctan2(sumsin, sumcos)
 
     xxm = X - xm
@@ -324,11 +521,13 @@ def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
     return cov
 
 
-def local_population(cell: np.ndarray,
-                     grid_pos: np.ndarray,
-                     target_grid_pos: np.ndarray,
-                     grid_weight: np.ndarray,
-                     s2: float):
+def local_population(
+    cell: np.ndarray,
+    grid_pos: np.ndarray,
+    target_grid_pos: np.ndarray,
+    grid_weight: np.ndarray,
+    s2: float,
+):
     """
     Calculates the local population of a set of vectors in a grid.
 
@@ -355,6 +554,7 @@ def local_population(cell: np.ndarray,
 
     return wl, num
 
+
 def effdim(cov):
     """
     Calculate the effective dimension of a covariance matrix based on Shannon entropy.
@@ -372,28 +572,30 @@ def effdim(cov):
     eigval = np.linalg.eigvals(cov)
     eigval /= sum(eigval)
     eigval *= np.log(eigval)
-    eigval[np.isnan(eigval)] = 0.
+    eigval[np.isnan(eigval)] = 0.0
 
     return np.exp(-sum(eigval))
 
+
 def oas(cov: np.ndarray, n: float, D: int):
     """Oracle approximating shrinkage (OAS) estimator
-    
+
     Args:
         cov: A covariance matrix
         n: The local population
         D: Dimension
-        
+
     Returns
         Covariance matrix
     """
 
     tr = np.trace(cov)
-    tr2 = tr ** 2
-    tr_cov2 = np.trace(cov ** 2)
+    tr2 = tr**2
+    tr_cov2 = np.trace(cov**2)
     phi = ((1 - 2 / D) * tr_cov2 + tr2) / ((n + 1 - 2 / D) * tr_cov2 - tr2 / D)
 
-    return (1 - phi) * cov + phi * np.eye(D) * tr /D
+    return (1 - phi) * cov + phi * np.eye(D) * tr / D
+
 
 def mahalanobis(period: np.ndarray, x: np.ndarray, y: np.ndarray, cov_inv: np.ndarray):
     """
@@ -413,6 +615,7 @@ def mahalanobis(period: np.ndarray, x: np.ndarray, y: np.ndarray, cov_inv: np.nd
     x, cov_inv = _mahalanobis_preprocess(x, cov_inv)
     return _mahalanobis(period, x, y, cov_inv)
 
+
 def _mahalanobis_preprocess(x: np.ndarray, cov_inv: np.ndarray):
 
     if len(x.shape) == 1:
@@ -421,6 +624,7 @@ def _mahalanobis_preprocess(x: np.ndarray, cov_inv: np.ndarray):
         cov_inv = cov_inv[np.newaxis, :, :]
 
     return x, cov_inv
+
 
 def _mahalanobis(period: np.ndarray, x: np.ndarray, y: np.ndarray, cov_inv: np.ndarray):
 
@@ -441,6 +645,7 @@ def _mahalanobis(period: np.ndarray, x: np.ndarray, y: np.ndarray, cov_inv: np.n
 
     return xcx
 
+
 def _update_probs(prob_i: float, lnks: np.ndarray):
 
     for lnk in lnks:
@@ -448,12 +653,14 @@ def _update_probs(prob_i: float, lnks: np.ndarray):
 
     return prob_i
 
+
 def _update_prob(prob_i: float, lnk: float):
 
     if prob_i > lnk:
         return prob_i + np.log(1 + np.exp(lnk - prob_i))
     else:
         return lnk + np.log(1 + np.exp(prob_i - lnk))
+
 
 class NearestNeighborClustering:
     """NearestNeighborClustering Class
@@ -464,6 +671,10 @@ class NearestNeighborClustering:
         self.labels_ = None
         self.period = period
         self._distance = pairwise_euclidean_distances
+        self.grid_pos = None
+        self.grid_npoints = None
+        self.grid_weight = None
+        self.grid_neighbour = None
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> None:
         """Fit the data. Generate the cluster center by FPS algorithm."""
@@ -474,16 +685,22 @@ class NearestNeighborClustering:
         self.grid_weight = np.zeros(ngrid, dtype=float)
         self.grid_neighbour = {i: [] for i in range(ngrid)}
 
-    def predict(self,
-                X: np.ndarray,
-                y: Optional[np.ndarray] = None,
-                sample_weight: Optional[np.ndarray] = None) -> np.ndarray:
+    def predict(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        sample_weight: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """Transform the data."""
         if sample_weight is None:
             sample_weight = np.ones(len(X)) / len(X)
         self.labels_ = []
-        for i, point in track(enumerate(X), description='Assigning samples to grids...', total=len(X)):
-            descriptor2grid = self._distance(X=point.reshape(1, -1), Y=self.grid_pos, cell=self.period)
+        for i, point in track(
+            enumerate(X), description="Assigning samples to grids...", total=len(X)
+        ):
+            descriptor2grid = self._distance(
+                X=point.reshape(1, -1), Y=self.grid_pos, cell=self.period
+            )
             self.labels_.append(np.argmin(descriptor2grid))
             self.grid_npoints[self.labels_[-1]] += 1
             self.grid_weight[self.labels_[-1]] += sample_weight[i]
@@ -495,13 +712,16 @@ class NearestNeighborClustering:
         return self.labels_
 
 
-def quick_shift(X: np.ndarray,
-                probs: np.ndarray,
-                dist_matrix: np.ndarray,
-                cutoff2: np.ndarray,
-                gs:float,
-                cell: np.ndarray,
-                thrpcl: float):
+def quick_shift(
+    X: np.ndarray,
+    probs: np.ndarray,
+    dist_matrix: np.ndarray,
+    cutoff2: np.ndarray,
+    normpks: float,
+    gs: float,
+    cell: np.ndarray,
+    thrpcl: float,
+):
     """
     Perform quick shift clustering on the given probability array and distance matrix.
 
@@ -514,9 +734,14 @@ def quick_shift(X: np.ndarray,
     Returns:
         tuple: A tuple containing the cluster centers and the root indices.
     """
-    from scipy.special import logsumexp as LSE
 
-    def gs_next(idx: int, probs: np.ndarray, n_shells: int, distmm: np.ndarray, gabriel: np.ndarray):
+    def gs_next(
+        idx: int,
+        probs: np.ndarray,
+        n_shells: int,
+        distmm: np.ndarray,
+        gabriel: np.ndarray,
+    ):
         """Find next cluster in Gabriel graph."""
 
         ngrid = len(probs)
@@ -531,15 +756,15 @@ def quick_shift(X: np.ndarray,
         next_idx = idx
         dmin = np.inf
         for j in range(ngrid):
-            if probs[j] > probs[idx] and \
-                distmm[idx, j] < dmin and \
-                neighs[j]:
+            if probs[j] > probs[idx] and distmm[idx, j] < dmin and neighs[j]:
                 next_idx = j
                 dmin = distmm[idx, j]
 
         return next_idx
 
-    def qs_next(idx:int, idxn: int, probs: np.ndarray, distmm: np.ndarray, lambda_: float):
+    def qs_next(
+        idx: int, idxn: int, probs: np.ndarray, distmm: np.ndarray, lambda_: float
+    ):
         """Find next cluster with respect to qscut(lambda_)."""
 
         ngrid = len(probs)
@@ -548,36 +773,32 @@ def quick_shift(X: np.ndarray,
         if probs[idxn] > probs[idx]:
             next_idx = idxn
         for j in range(ngrid):
-            if probs[j] > probs[idx] and \
-                distmm[idx, j] < dmin and \
-                distmm[idx, j] < lambda_:
+            if (
+                probs[j] > probs[idx]
+                and distmm[idx, j] < dmin
+                and distmm[idx, j] < lambda_
+            ):
                 next_idx = j
                 dmin = distmm[idx, j]
 
         return next_idx
-    
-    def logsumexp(v1: np.ndarray, probs: np.ndarray, clusterid: int):
 
-        mask = v1 == clusterid
-        probs = np.copy(probs)
-        probs[~mask] = -np.inf
-
-        return LSE(probs)
-    
     def getidmax(v1: np.ndarray, probs: np.ndarray, clusterid: int):
 
         tmpv = np.copy(probs)
         tmpv[v1 != clusterid] = -np.inf
         return np.argmax(tmpv)
 
-    def post_process(cluster_centers: np.ndarray,
-                     grid_pos: np.ndarray,
-                     idxroot: np.ndarray,
-                     probs: np.ndarray,
-                     cell: np.ndarray,
-                     thrpcl: float):
+    def post_process(
+        normpks: float,
+        cluster_centers: np.ndarray,
+        grid_pos: np.ndarray,
+        idxroot: np.ndarray,
+        probs: np.ndarray,
+        cell: np.ndarray,
+        thrpcl: float,
+    ):
 
-        normpks = logsumexp(np.ones(dist_matrix.shape[0]), probs, 1)
         nk = len(cluster_centers)
         to_merge = np.full(nk, False)
         for k in range(nk):
@@ -593,13 +814,16 @@ def quick_shift(X: np.ndarray,
                 if to_merge[k]:
                     continue
                 dummd2 = pairwise_euclidean_distances(
-                    grid_pos[idxroot[dummd1yi1]], grid_pos[idxroot[j]], cell=cell)
+                    grid_pos[idxroot[dummd1yi1]], grid_pos[idxroot[j]], cell=cell
+                )
                 if dummd2 < dummd1:
                     dummd1 = dummd2
                     cluster_centers[i] = j
             idxroot[idxroot == dummd1yi1] = cluster_centers[i]
         if sum(to_merge) > 0:
-            cluster_centers = np.concatenate(np.argwhere(idxroot == np.arange(len(idxroot))))
+            cluster_centers = np.concatenate(
+                np.argwhere(idxroot == np.arange(len(idxroot)))
+            )
             nk = len(cluster_centers)
             for i in range(nk):
                 dummd1yi1 = cluster_centers[i]
@@ -611,25 +835,34 @@ def quick_shift(X: np.ndarray,
     gabrial = get_gabriel_graph(dist_matrix)
     idmindist = np.argmin(dist_matrix, axis=1)
     idxroot = np.full(dist_matrix.shape[0], -1, dtype=int)
-    for i in track(range(dist_matrix.shape[0]), description='Quick-Shift'):
+    for i in track(range(dist_matrix.shape[0]), description="Quick-Shift"):
         if idxroot[i] != -1:
             continue
         qspath = []
         qspath.append(i)
         while qspath[-1] != idxroot[qspath[-1]]:
             if gs > 0:
-                idxroot[qspath[-1]] = gs_next(qspath[-1], probs, gs,
-                                              dist_matrix, gabrial)
+                idxroot[qspath[-1]] = gs_next(
+                    qspath[-1], probs, gs, dist_matrix, gabrial
+                )
             else:
-                idxroot[qspath[-1]] = qs_next(qspath[-1], idmindist[qspath[-1]],
-                                              probs, dist_matrix, cutoff2[qspath[-1]])
+                idxroot[qspath[-1]] = qs_next(
+                    qspath[-1],
+                    idmindist[qspath[-1]],
+                    probs,
+                    dist_matrix,
+                    cutoff2[qspath[-1]],
+                )
             if idxroot[idxroot[qspath[-1]]] != -1:
                 break
             qspath.append(idxroot[qspath[-1]])
         idxroot[qspath] = idxroot[idxroot[qspath[-1]]]
-    cluster_centers = np.concatenate(np.argwhere(idxroot == np.arange(dist_matrix.shape[0])))
+    cluster_centers = np.concatenate(
+        np.argwhere(idxroot == np.arange(dist_matrix.shape[0]))
+    )
 
-    return post_process(cluster_centers, X, idxroot, probs, cell, thrpcl)
+    return post_process(normpks, cluster_centers, X, idxroot, probs, cell, thrpcl)
+
 
 def get_gabriel_graph(dist_matrix2: np.ndarray):
     """
@@ -646,7 +879,7 @@ def get_gabriel_graph(dist_matrix2: np.ndarray):
 
     n_points = dist_matrix2.shape[0]
     gabriel = np.full((n_points, n_points), True)
-    for i in track(range(n_points), description='Calculating Gabriel graph'):
+    for i in track(range(n_points), description="Calculating Gabriel graph"):
         gabriel[i, i] = False
         for j in range(i, n_points):
             if np.sum(dist_matrix2[i] + dist_matrix2[j] < dist_matrix2[i, j]):
@@ -655,3 +888,36 @@ def get_gabriel_graph(dist_matrix2: np.ndarray):
 
     return gabriel
 
+
+from scipy.special import logsumexp as LSE
+
+
+def logsumexp(v1: np.ndarray, probs: np.ndarray, clusterid: int):
+
+    mask = v1 == clusterid
+    probs = np.copy(probs)
+    probs[~mask] = -np.inf
+
+    return LSE(probs)
+
+
+def rij(period: np.ndarray, xi: np.ndarray, xj: np.ndarray):
+    """
+    Calculates the period-concerned position vector.
+    Args:
+        period (np.ndarray): An array of periods for each dimension of the points.
+        -1 stands for not periodic.
+        xij (np.ndarray): An array for storing the result.
+        xi (np.ndarray): An array of point coordinates. It can also contain many points.
+        Shape: (n_points, n_dimensions)
+        xj (np.ndarray): An array of point coordinates. It can only contain one point.
+
+    Returns:
+        xij (np.ndarray): An array of position vectors. Shape: (n_points, n_dimensions)
+    """
+
+    xij = xi - xj
+    if period is not None:
+        xij -= np.round(xij / period) * period
+
+    return xij

--- a/src/skmatter/neighbors/_sparsekde.py
+++ b/src/skmatter/neighbors/_sparsekde.py
@@ -1,5 +1,11 @@
+import warnings
+from typing import Union, Optional
 from sklearn.base import BaseEstimator
+from sklearn.utils.validation import _check_sample_weight
 import numpy as np
+from rich.progress import track
+
+from ..metrics.pairwise import pairwise_euclidean_distances
 
 class SparseKDE(BaseEstimator):
     """A sparse implementation of the Kernel Density Estimation.
@@ -20,10 +26,27 @@ class SparseKDE(BaseEstimator):
         Additional parameters to be passed to the use of
         metric.  i.e. the cell dimension for `periodic_euclidean`
     """
-    def __init__(kernel, metric, metric_params):
-        ...
+    def __init__(self, kernel, metric, metric_params,
+                 descriptors: np.ndarray, weights: np.ndarray,
+                 qs:float = 1., gs:int = -1,
+                 fspread:float = -1., fpoints:float = 0.15):
+        self.kernel = kernel
+        self.metric = metric
+        self.metric_params = metric_params
+        self.cell = metric_params['cell'] if 'cell' in metric_params else None
+        self.descriptors = descriptors
+        self.weight = weights if weights is not None else np.ones(len(descriptors)) / len(descriptors)
+        self.nsamples = len(descriptors)
+        self.qs = qs
+        self.gs = gs
+        self.fspread = fspread
+        self.fpoints = fpoints
+        self.kdecut2 = None
 
-    def fit(self, X, y=None, sample_weight=None):
+        if self.fspread > 0:
+            self.fpoints = -1.
+
+    def fit(self, X, y=None, sample_weight=None, igrid=None):
         """Fit the Kernel Density model on the data.
 
         Parameters
@@ -46,7 +69,25 @@ class SparseKDE(BaseEstimator):
         self : object
             Returns the instance itself.
         """
-        ...
+
+        # if sample_weight is not None:
+        #     sample_weight = _check_sample_weight(
+        #         sample_weight, X, dtype=np.float64, only_non_negative=True
+        #     )
+        # else:
+        #     sample_weight = np.ones(X.shape[0], dtype=np.float64) / X.shape[0]
+        self.kdecut2 = 9 * (np.sqrt(X.shape[1]) + 1) ** 2
+        grid_dist_mat = pairwise_euclidean_distances(X, X, squared=True, cell=self.cell)
+        np.fill_diagonal(grid_dist_mat, np.inf)
+        min_grid_dist = np.min(grid_dist_mat, axis=1)
+        grid_npoints, grid_neighbour, sample_labels_, sample_weight = self._assign_descriptors_to_grids(X)
+        h_invs, normkernels, qscut2 = self._computes_localization(X, sample_weight, min_grid_dist)
+        probs = self._computes_kernel_density_estimation(X, sample_weight, h_invs, normkernels, \
+                                                         igrid, grid_neighbour)
+
+        return probs
+
+
 
     def score_samples(self, X):
         """Compute the log-likelihood of each sample under the model.
@@ -110,3 +151,343 @@ class SparseKDE(BaseEstimator):
             List of samples.
         """
         ...
+
+    def _assign_descriptors_to_grids(self, X):
+
+        assigner = NearestNeighborClustering(self.cell)
+        assigner.fit(X)
+        labels = assigner.predict(self.descriptors, sample_weight=self.weight)
+        grid_npoints = assigner.grid_npoints
+        grid_neighbour = assigner.grid_neighbour
+
+        return grid_npoints, grid_neighbour, labels, assigner.grid_weight
+
+    def _computes_localization(self, X, sample_weights: np.ndarray, mindist: np.ndarray):
+
+        cov = covariance(X, sample_weights, self.cell)
+
+        if self.cell is not None:
+            tune = sum(self.cell ** 2)
+        else:
+            tune = np.trace(cov)
+
+        sigma2 = np.full(len(X), tune, dtype=float)
+        # initialize the localization based on fraction of data spread
+        if self.fspread > 0:
+            sigma2 *= self.fspread ** 2
+        flocal, normkernels, qscut2, h_tr_normed = \
+            np.zeros(len(X)), np.zeros(len(X)), np.zeros(len(X)), np.zeros(len(X))
+        h_invs = np.zeros((len(X), X.shape[1], X.shape[1]))
+
+        for i in track(range(len(X)), description='Estimating kernel density bandwidths'):
+            wlocal, flocal[i] = local_population(self.cell, X, X[i],
+                                                 sample_weights, sigma2[i])
+            if self.fpoints > 0:
+                sigma2, flocal, wlocal = \
+                    self._localization_based_on_fraction_of_points(
+                        X, sample_weights, sigma2, flocal, i, 1 / self.nsamples, tune)
+            elif sigma2[i] < flocal[i]:
+                sigma2, flocal, wlocal = \
+                    self._localization_based_on_fraction_of_spread(X, sample_weights, sigma2, flocal, i, mindist)
+            h_invs[i], normkernels[i], qscut2[i], h_tr_normed[i] = \
+                self._bandwidth_estimation_from_localization(X, sample_weights, wlocal, flocal, i)
+
+        qscut2 *= self.qs ** 2
+
+        return h_invs, normkernels, qscut2
+
+    def _localization_based_on_fraction_of_points(self, X, sample_weights, sigma2, flocal, idx, delta, tune):
+        """Used in cases where one expects clusterswith very different spreads, 
+        but similar populations"""
+
+        lim = self.fpoints
+        if lim <= sample_weights[idx]:
+            lim = sample_weights[idx] + delta
+            warnings.warn(" Warning: localization smaller than voronoi,"
+                          " increase grid size (meanwhile adjusted localization)!")
+        while flocal[idx] < lim:
+            sigma2[idx] += tune
+            wlocal, flocal[idx] = local_population(self.cell, X, X[idx],
+                                                   sample_weights, sigma2[idx])
+        j = 1
+        while True:
+            if flocal[idx] > lim:
+                sigma2[idx] -= tune / 2 ** j
+            else:
+                sigma2[idx] += tune / 2 ** j
+            wlocal, flocal[idx] = local_population(self.cell, X, X[idx],
+                                                   sample_weights, sigma2[idx])
+            if abs(flocal[idx] - lim) < delta:
+                break
+            j += 1
+
+        return sigma2, flocal, wlocal
+
+    def _localization_based_on_fraction_of_spread(self, X, sample_weights, sigma2, flocal, idx, mindist):
+
+        sigma2[idx] = mindist[idx]
+        wlocal, flocal[idx] = local_population(self.cell, self.descriptors, X,
+                                               sample_weights, sigma2[idx])
+
+        return sigma2, flocal, wlocal
+
+    def _bandwidth_estimation_from_localization(self, X, sample_weights, wlocal, flocal, idx):
+
+        cov_i = covariance(X, wlocal, self.cell)
+        nlocal = flocal[idx] * self.nsamples
+        local_dimension = effdim(cov_i)
+        cov_i = oas(cov_i, nlocal, X.shape[1])
+        # localized version of Silverman's rule
+        h = (4. / nlocal / (local_dimension + 2.)) ** (2. / (local_dimension + 4.)) * cov_i
+        h_tr_normed = np.trace(h) / h.shape[0]
+        h_inv = np.linalg.inv(h)
+        _, logdet_h = np.linalg.slogdet(h)
+        normkernel = X.shape[1] * np.log(2 * np.pi) + logdet_h
+        qscut2 = np.trace(cov_i)
+
+        return  h_inv, normkernel, qscut2, h_tr_normed
+
+    def _computes_kernel_density_estimation(self,
+                                            X: np.ndarray,
+                                            sample_weights: np.ndarray,
+                                            h_inv: np.ndarray,
+                                            normkernel: np.ndarray,
+                                            igrid: np.ndarray,
+                                            neighbour: dict):
+
+        prob = np.full(len(X), -np.inf)
+        for i in track(range(len(X)), description='Computing kernel density on reference points'):
+            dummd1s = mahalanobis(self.cell, X, X[i], h_inv)
+            for j, dummd1 in enumerate(dummd1s):
+                if dummd1 > self.kdecut2:
+                    lnk = -0.5 * (normkernel[j] + dummd1) + np.log(sample_weights[j])
+                    prob[i] = _update_prob(prob[i], lnk)
+                else:
+                    neighbours = neighbour[j][neighbour[j] != igrid[i]]
+                    dummd1s = mahalanobis(self.cell, self.descriptors[neighbours],
+                                          X[i], h_inv[j])
+                    lnks = -0.5 * (normkernel[j] + dummd1s) + np.log(self.weight[neighbours])
+                    prob[i] = _update_probs(prob[i], lnks)
+
+        prob -= np.log(np.sum(sample_weights))
+
+        return prob
+
+
+
+def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
+    """
+    Calculate the covariance matrix for a given set of grid positions and weights.
+
+    Parameters:
+        grid_pos (np.ndarray): An array of shape (nsample, dimension)
+        representing the grid positions.
+        period (np.ndarray): An array of shape (dimension,)
+        representing the periodicity of each dimension.
+        grid_weight (np.ndarray): An array of shape (nsample,)
+        representing the weights of the grid positions.
+
+    Returns:
+        cov (np.ndarray): The covariance matrix of shape (dimension, dimension).
+
+    Note:
+        The function assumes that the grid positions, weights, and total weight are provided correctly.
+        The function handles periodic and non-periodic dimensions differently to calculate the covariance matrix.
+    """
+
+    nsample = X.shape[0]
+    dimension = X.shape[1]
+    xm = np.zeros(dimension)
+    xxm = np.zeros((nsample, dimension))
+    xxmw = np.zeros((nsample, dimension))
+    totw = np.sum(sample_weights)
+
+    if cell is None:
+        xm = np.average(X, axis=0, weights=sample_weights / totw)
+    else:
+        for i in range(dimension):
+            sumsin = np.sum(sample_weights * np.sin(X[:, i]) *\
+                            (2 * np.pi) / cell[i]) / totw
+            sumcos = np.sum(sample_weights * np.cos(X[:, i]) *\
+                            (2 * np.pi) / cell[i]) / totw
+            xm[i] = np.arctan2(sumsin, sumcos)
+
+    xxm = X - xm
+    if cell is not None:
+        xxm -= np.round(xxm / cell) * cell
+    xxmw = xxm * sample_weights.reshape(-1, 1) / totw
+    cov = xxmw.T.dot(xxm)
+    cov /= 1 - sum((sample_weights / totw) ** 2)
+
+    return cov
+
+
+def local_population(cell: np.ndarray,
+                     grid_pos: np.ndarray,
+                     target_grid_pos: np.ndarray,
+                     grid_weight: np.ndarray,
+                     s2: float):
+    """
+    Calculates the local population of a set of vectors in a grid.
+
+    Args:
+        cell (np.ndarray): An array of periods for each dimension of the grid.
+        x (np.ndarray): An array of vectors to be localized.
+        y (np.ndarray): An array of target vectors representing the grid.
+        grid_weight (np.ndarray): An array of weights for each target vector.
+        s2 (float): The scaling factor for the squared distance.
+
+    Returns:
+        tuple: A tuple containing two numpy arrays:
+            wl (np.ndarray): An array of localized weights for each vector.
+            num (np.ndarray): The sum of the localized weights.
+
+    """
+
+    xy = grid_pos - target_grid_pos
+    if cell is not None:
+        xy -= np.round(xy / cell) * cell
+
+    wl = np.exp(-0.5 / s2 * np.sum(xy**2, axis=1)) * grid_weight
+    num = np.sum(wl)
+
+    return wl, num
+
+def effdim(cov):
+    """
+    Calculate the effective dimension of a covariance matrix based on Shannon entropy.
+
+    Parameters:
+        cov (ndarray): The covariance matrix.
+
+    Returns:
+        float: The effective dimension of the covariance matrix.
+
+    Ref:
+        https://ieeexplore.ieee.org/document/7098875
+    """
+
+    eigval = np.linalg.eigvals(cov)
+    eigval /= sum(eigval)
+    eigval *= np.log(eigval)
+    eigval[np.isnan(eigval)] = 0.
+
+    return np.exp(-sum(eigval))
+
+def oas(cov: np.ndarray, n: float, D: int):
+    """Oracle approximating shrinkage (OAS) estimator
+    
+    Args:
+        cov: A covariance matrix
+        n: The local population
+        D: Dimension
+        
+    Returns
+        Covariance matrix
+    """
+
+    tr = np.trace(cov)
+    tr2 = tr ** 2
+    tr_cov2 = np.trace(cov ** 2)
+    phi = ((1 - 2 / D) * tr_cov2 + tr2) / ((n + 1 - 2 / D) * tr_cov2 - tr2 / D)
+
+    return (1 - phi) * cov + phi * np.eye(D) * tr /D
+
+def mahalanobis(period: np.ndarray, x: np.ndarray, y: np.ndarray, cov_inv: np.ndarray):
+    """
+    Calculates the Mahalanobis distance between two vectors.
+
+    Args:
+        period (np.ndarray): An array of periods for each dimension of vectors.
+        x (np.ndarray): An array of vectors to be localized.
+        y (np.ndarray): An array of target vectors.
+        cov_inv (np.ndarray): The inverse of the covariance matrix.
+
+    Returns:
+        float: The Mahalanobis distance.
+
+    """
+
+    x, cov_inv = _mahalanobis_preprocess(x, cov_inv)
+    return _mahalanobis(period, x, y, cov_inv)
+
+def _mahalanobis_preprocess(x: np.ndarray, cov_inv: np.ndarray):
+
+    if len(x.shape) == 1:
+        x = x[np.newaxis, :]
+    if len(cov_inv.shape) == 2:
+        cov_inv = cov_inv[np.newaxis, :, :]
+
+    return x, cov_inv
+
+def _mahalanobis(period: np.ndarray, x: np.ndarray, y: np.ndarray, cov_inv: np.ndarray):
+
+    tmpv = np.zeros(x.shape, dtype=float)
+    xcx = np.zeros(x.shape[0], dtype=float)
+    xy = x - y
+    if period is not None:
+        xy -= np.round(xy / period) * period
+    if cov_inv.shape[0] == 1:
+        # many samples and one cov
+        tmpv = xy.dot(cov_inv[0])
+    else:
+        # many samples and many cov
+        for i in range(x.shape[0]):
+            tmpv[i] = np.dot(xy[i], cov_inv[i])
+    for i in range(x.shape[0]):
+        xcx[i] = np.dot(xy[i], tmpv[i].T)
+
+    return xcx
+
+def _update_probs(prob_i: float, lnks: np.ndarray):
+
+    for lnk in lnks:
+        prob_i = _update_prob(prob_i, lnk)
+
+    return prob_i
+
+def _update_prob(prob_i: float, lnk: float):
+
+    if prob_i > lnk:
+        return prob_i + np.log(1 + np.exp(lnk - prob_i))
+    else:
+        return lnk + np.log(1 + np.exp(prob_i - lnk))
+
+class NearestNeighborClustering:
+    """NearestNeighborClustering Class
+    Assign descriptor to its nearest grid."""
+
+    def __init__(self, period: Optional[np.ndarray] = None) -> None:
+
+        self.labels_ = None
+        self.period = period
+        self._distance = pairwise_euclidean_distances
+
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> None:
+        """Fit the data. Generate the cluster center by FPS algorithm."""
+
+        ngrid = len(X)
+        self.grid_pos = X
+        self.grid_npoints = np.zeros(ngrid, dtype=int)
+        self.grid_weight = np.zeros(ngrid, dtype=float)
+        self.grid_neighbour = {i: [] for i in range(ngrid)}
+
+    def predict(self,
+                X: np.ndarray,
+                y: Optional[np.ndarray] = None,
+                sample_weight: Optional[np.ndarray] = None) -> np.ndarray:
+        """Transform the data."""
+        if sample_weight is None:
+            sample_weight = np.ones(len(X)) / len(X)
+        self.labels_ = []
+        for i, point in track(enumerate(X), description='Assigning samples to grids...', total=len(X)):
+            descriptor2grid = self._distance(X=point.reshape(1, -1), Y=self.grid_pos, cell=self.period)
+            self.labels_.append(np.argmin(descriptor2grid))
+            self.grid_npoints[self.labels_[-1]] += 1
+            self.grid_weight[self.labels_[-1]] += sample_weight[i]
+            self.grid_neighbour[self.labels_[-1]].append(i)
+
+        for key in self.grid_neighbour:
+            self.grid_neighbour[key] = np.array(self.grid_neighbour[key])
+
+        return self.labels_

--- a/src/skmatter/neighbors/_sparsekde.py
+++ b/src/skmatter/neighbors/_sparsekde.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional
+from typing import Union
 
 import numpy as np
 from scipy.special import logsumexp as LSE
@@ -114,10 +114,10 @@ class SparseKDE(BaseEstimator):
     def __init__(
         self,
         descriptors: np.ndarray,
-        weights: Optional[np.ndarray] = None,
+        weights: Union[np.ndarray, None] = None,
         kernel: str = "gaussian",
         metric: str = "periodic_euclidean",
-        metric_params: Optional[dict] = None,
+        metric_params: Union[dict, None] = None,
         qs: float = 1.0,
         gs: int = -1,
         thrpcl: float = 0.0,

--- a/src/skmatter/neighbors/_sparsekde.py
+++ b/src/skmatter/neighbors/_sparsekde.py
@@ -64,7 +64,7 @@ class SparseKDE(BaseEstimator):
     nmsopt : int, default=0
         The number of mean-shift refinement steps.
 
-    
+
     Attributes
     ----------
     kdecut2 : float

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -114,6 +114,31 @@ class GaussianMixtureModel:
             return sum_p
 
         return np.sum(p[i]) / sum_p
+    
+    def sample(self, n_samples=1, random_state=None):
+        """Generate random samples from the model.
+
+        Currently, this is implemented only for gaussian and tophat kernels.
+
+        Parameters
+        ----------
+        n_samples : int, default=1
+            Number of samples to generate.
+
+        random_state : int or None, default=None
+            Determines random number generation used to generate
+            random samples. Pass an int for reproducible results
+            across multiple function calls.
+            See :term:`Glossary <random_state>`.
+
+        Returns
+        -------
+        X : array-like of shape (n_samples, n_features)
+            List of samples.
+        """
+        return np.random.multivariate_normal(
+            mean=self.means, cov=self.covariances, size=n_samples
+        )
 
 
 def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -1,7 +1,7 @@
 """This file holds utility functions and classes for the sparse KDE."""
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 from tqdm import tqdm
@@ -114,7 +114,7 @@ class GaussianMixtureModel:
     weights: np.ndarray
     means: np.ndarray
     covariances: np.ndarray
-    cell: Optional[np.ndarray] = None
+    cell: Union[np.ndarray, None] = None
     """
     A Gaussian Mixture Model for clustering and density estimation.
 
@@ -148,7 +148,7 @@ class GaussianMixtureModel:
         self.cov_dets = np.linalg.det(self.covariances)
         self.norms = 1 / np.sqrt((2 * np.pi) ** self.dimension * self.cov_dets)
 
-    def __call__(self, x: np.ndarray, i: Optional[Union[int, list[int]]] = None):
+    def __call__(self, x: np.ndarray, i: Union[int, list[int], None] = None):
         """
         Calculate the probability density function (PDF) value for a given input array.
 

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -5,23 +5,22 @@ from typing import Optional, Union
 from tqdm import tqdm
 
 import numpy as np
-from ..metrics.pairwise import pairwise_euclidean_distances
 
 
 class NearestGridAssigner:
     """NearestGridAssigner Class
-    Assign descriptor to its nearest grid.
+    Assign descriptor to its nearest grid. This is an axulirary class.
     
     Args:
         cell (np.ndarray): An array of periods for each dimension of the grid.
         exclude_grid (bool): Whether to exclude the grid itself from neighbor lists."""
 
-    def __init__(self, cell: Optional[np.ndarray] = None, exclude_grid: bool = True) -> None:
+    def __init__(self, metric, cell: Optional[np.ndarray] = None, exclude_grid: bool = True) -> None:
 
         self.labels_ = None
+        self.metric = metric
         self.cell = cell
         self.exclude_grid = exclude_grid
-        self._distance = pairwise_euclidean_distances
         self.grid_pos = None
         self.grid_npoints = None
         self.grid_weight = None
@@ -49,7 +48,7 @@ class NearestGridAssigner:
         for i, point in tqdm(
             enumerate(X), desc="Assigning samples to grids...", total=len(X)
         ):
-            descriptor2grid = self._distance(
+            descriptor2grid = self.metric(
                 X=point.reshape(1, -1), Y=self.grid_pos, cell=self.cell
             )
             self.labels_.append(np.argmin(descriptor2grid))
@@ -69,6 +68,7 @@ class GaussianMixtureModel:
     means: np.ndarray
     covariances: np.ndarray
     period: Optional[np.ndarray] = None
+    """A simple class for Gaussian Mixture Model. This is an axulirary class."""
 
     def __post_init__(self):
         self.dimension = self.means.shape[1]

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -38,7 +38,7 @@ class NearestGridAssigner:
     def __init__(
         self,
         metric,
-        cell: Optional[np.ndarray] = None,
+        cell: Union[np.ndarray, None] = None,
     ) -> None:
 
         self.labels_ = None
@@ -49,7 +49,7 @@ class NearestGridAssigner:
         self.grid_weight = None
         self.grid_neighbour = None
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> None:
+    def fit(self, X: np.ndarray, y: Union[np.ndarray, None] = None) -> None:
         """Fit the data.
 
         Parameters
@@ -69,8 +69,8 @@ class NearestGridAssigner:
     def predict(
         self,
         X: np.ndarray,
-        y: Optional[np.ndarray] = None,
-        sample_weight: Optional[np.ndarray] = None,
+        y: Union[np.ndarray, None] = None,
+        sample_weight: Union[np.ndarray, None] = None,
     ) -> np.ndarray:
         """
         Predicts labels for input data and returns an array of labels.
@@ -472,7 +472,7 @@ def get_gabriel_graph(dist_matrix2: np.ndarray):
     return gabriel
 
 
-def rij(period: Optional[np.ndarray], xi: np.ndarray, xj: np.ndarray) -> np.ndarray:
+def rij(period: Union[np.ndarray, None], xi: np.ndarray, xj: np.ndarray) -> np.ndarray:
     """
     Calculate the position vector considering the periodic boundary conditions.
 

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -1,0 +1,437 @@
+"""This file holds utility functions and classes for the sparse KDE."""
+
+from dataclasses import dataclass
+from typing import Optional, Union
+from tqdm import tqdm
+
+import numpy as np
+from scipy.special import logsumexp as LSE
+from ..metrics.pairwise import pairwise_euclidean_distances
+
+
+class NearestGridAssigner:
+    """NearestGridAssigner Class
+    Assign descriptor to its nearest grid."""
+
+    def __init__(self, period: Optional[np.ndarray] = None) -> None:
+
+        self.labels_ = None
+        self.period = period
+        self._distance = pairwise_euclidean_distances
+        self.grid_pos = None
+        self.grid_npoints = None
+        self.grid_weight = None
+        self.grid_neighbour = None
+
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> None:
+        """Fit the data. Generate the cluster center by FPS algorithm."""
+
+        ngrid = len(X)
+        self.grid_pos = X
+        self.grid_npoints = np.zeros(ngrid, dtype=int)
+        self.grid_weight = np.zeros(ngrid, dtype=float)
+        self.grid_neighbour = {i: [] for i in range(ngrid)}
+
+    def predict(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        sample_weight: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Transform the data."""
+        if sample_weight is None:
+            sample_weight = np.ones(len(X)) / len(X)
+        self.labels_ = []
+        for i, point in tqdm(
+            enumerate(X), desc="Assigning samples to grids...", total=len(X)
+        ):
+            descriptor2grid = self._distance(
+                X=point.reshape(1, -1), Y=self.grid_pos, cell=self.period
+            )
+            self.labels_.append(np.argmin(descriptor2grid))
+            self.grid_npoints[self.labels_[-1]] += 1
+            self.grid_weight[self.labels_[-1]] += sample_weight[i]
+            self.grid_neighbour[self.labels_[-1]].append(i)
+
+        for key in self.grid_neighbour:
+            self.grid_neighbour[key] = np.array(self.grid_neighbour[key])
+
+        return self.labels_
+
+
+@dataclass
+class GaussianMixtureModel:
+    weights: np.ndarray
+    means: np.ndarray
+    covariances: np.ndarray
+    period: Optional[np.ndarray] = None
+
+    def __post_init__(self):
+        self.dimension = self.means.shape[1]
+        self.cov_inv = np.linalg.inv(self.covariances)
+        self.cov_det = np.linalg.det(self.covariances)
+        self.norm = 1 / np.sqrt((2 * np.pi) ** self.dimension * self.cov_det)
+
+    def __call__(self, x: np.ndarray, i: Optional[Union[int, list[int]]] = None):
+        """
+        Calculate the probability density function (PDF) value for a given input array.
+
+        Parameters:
+            x (np.ndarray): The input array for which the PDF is calculated. Once a point.
+            i (Optional[int]): The index of the element in the PDF array to return.
+                If None, the sum of all elements is returned.
+
+        Returns:
+            float or np.ndarray: The PDF value(s) for the given input(s).
+                If i is None, the sum of all PDF values is returned.
+                If i is specified, the normalized value of the corresponding gaussian is returned.
+
+        Raises:
+            None
+
+        Example:
+            >>> obj = ClassName()
+            >>> obj.__call__(x, i)
+            0.123456789
+        """
+
+        if len(x.shape) == 1:
+            x = x[np.newaxis, :]
+        if self.period is not None:
+            xij = np.zeros(self.means.shape)
+            xij = rij(self.period, x, self.means)
+        else:
+            xij = x - self.means
+        p = (
+            self.weights
+            * self.norm
+            * np.exp(
+                -0.5 * (xij[:, np.newaxis, :] @ self.cov_inv @ xij[:, :, np.newaxis])
+            ).reshape(-1)
+        )
+        sum_p = np.sum(p)
+        if i is None:
+            return sum_p
+
+        return np.sum(p[i]) / sum_p
+
+
+def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
+    """
+    Calculate the covariance matrix for a given set of grid positions and weights.
+
+    Parameters:
+        grid_pos (np.ndarray): An array of shape (nsample, dimension)
+        representing the grid positions.
+        period (np.ndarray): An array of shape (dimension,)
+        representing the periodicity of each dimension.
+        grid_weight (np.ndarray): An array of shape (nsample,)
+        representing the weights of the grid positions.
+
+    Returns:
+        cov (np.ndarray): The covariance matrix of shape (dimension, dimension).
+
+    Note:
+        The function assumes that the grid positions, weights, and total weight are provided correctly.
+        The function handles periodic and non-periodic dimensions differently to calculate the covariance matrix.
+    """
+
+    totw = np.sum(sample_weights)
+
+    if cell is None:
+        xm = np.average(X, axis=0, weights=sample_weights / totw)
+    else:
+        sumsin = np.average(
+            np.sin(X) * (2 * np.pi) / cell,
+            axis=0,
+            weights=sample_weights / totw,
+        )
+        sumcos = np.average(
+            np.cos(X) * (2 * np.pi) / cell,
+            axis=0,
+            weights=sample_weights / totw,
+        )
+        xm = np.arctan2(sumsin, sumcos)
+
+    xxm = X - xm
+    if cell is not None:
+        xxm -= np.round(xxm / cell) * cell
+    xxmw = xxm * sample_weights.reshape(-1, 1) / totw
+    cov = xxmw.T.dot(xxm)
+    cov /= 1 - sum((sample_weights / totw) ** 2)
+
+    return cov
+
+
+def local_population(
+    cell: np.ndarray,
+    grid_pos: np.ndarray,
+    target_grid_pos: np.ndarray,
+    grid_weight: np.ndarray,
+    s2: float,
+):
+    """
+    Calculates the local population of a set of vectors in a grid.
+
+    Args:
+        cell (np.ndarray): An array of periods for each dimension of the grid.
+        x (np.ndarray): An array of vectors to be localized.
+        y (np.ndarray): An array of target vectors representing the grid.
+        grid_weight (np.ndarray): An array of weights for each target vector.
+        s2 (float): The scaling factor for the squared distance.
+
+    Returns:
+        tuple: A tuple containing two numpy arrays:
+            wl (np.ndarray): An array of localized weights for each vector.
+            num (np.ndarray): The sum of the localized weights.
+
+    """
+
+    xy = grid_pos - target_grid_pos
+    if cell is not None:
+        xy -= np.round(xy / cell) * cell
+
+    wl = np.exp(-0.5 / s2 * np.sum(xy**2, axis=1)) * grid_weight
+    num = np.sum(wl)
+
+    return wl, num
+
+
+def effdim(cov):
+    """
+    Calculate the effective dimension of a covariance matrix based on Shannon entropy.
+
+    Parameters:
+        cov (ndarray): The covariance matrix.
+
+    Returns:
+        float: The effective dimension of the covariance matrix.
+
+    Ref:
+        https://ieeexplore.ieee.org/document/7098875
+    """
+
+    eigval = np.linalg.eigvals(cov)
+    eigval /= sum(eigval)
+    eigval *= np.log(eigval)
+    eigval[np.isnan(eigval)] = 0.0
+
+    return np.exp(-sum(eigval))
+
+
+def oas(cov: np.ndarray, n: float, D: int):
+    """Oracle approximating shrinkage (OAS) estimator
+
+    Args:
+        cov: A covariance matrix
+        n: The local population
+        D: Dimension
+
+    Returns
+        Covariance matrix
+    """
+
+    tr = np.trace(cov)
+    tr2 = tr**2
+    tr_cov2 = np.trace(cov**2)
+    phi = ((1 - 2 / D) * tr_cov2 + tr2) / ((n + 1 - 2 / D) * tr_cov2 - tr2 / D)
+
+    return (1 - phi) * cov + phi * np.eye(D) * tr / D
+
+
+def quick_shift(
+    X: np.ndarray,
+    probs: np.ndarray,
+    dist_matrix: np.ndarray,
+    cutoff2: np.ndarray,
+    normpks: float,
+    gs: float,
+    cell: np.ndarray,
+    thrpcl: float,
+):
+    """
+    Perform quick shift clustering on the given probability array and distance matrix.
+
+    Args:
+        probs (np.ndarray): The log-likelihood of each sample.
+        dist_matrix (np.ndarray): The squared distance matrix.
+        cutoff2 (np.ndarray): The squared cutoff array.
+        gs (float): The value of gs.
+
+    Returns:
+        tuple: A tuple containing the cluster centers and the root indices.
+    """
+
+    def gs_next(
+        idx: int,
+        probs: np.ndarray,
+        n_shells: int,
+        distmm: np.ndarray,
+        gabriel: np.ndarray,
+    ):
+        """Find next cluster in Gabriel graph."""
+
+        ngrid = len(probs)
+        neighs = np.copy(gabriel[idx])
+        for _ in range(1, n_shells):
+            nneighs = np.full(ngrid, False)
+            for j in range(ngrid):
+                if neighs[j]:
+                    nneighs |= gabriel[j]
+            neighs |= nneighs
+
+        next_idx = idx
+        dmin = np.inf
+        for j in range(ngrid):
+            if probs[j] > probs[idx] and distmm[idx, j] < dmin and neighs[j]:
+                next_idx = j
+                dmin = distmm[idx, j]
+
+        return next_idx
+
+    def qs_next(
+        idx: int, idxn: int, probs: np.ndarray, distmm: np.ndarray, lambda_: float
+    ):
+        """Find next cluster with respect to qscut(lambda_)."""
+
+        ngrid = len(probs)
+        dmin = np.inf
+        next_idx = idx
+        if probs[idxn] > probs[idx]:
+            next_idx = idxn
+        for j in range(ngrid):
+            if (
+                probs[j] > probs[idx]
+                and distmm[idx, j] < dmin
+                and distmm[idx, j] < lambda_
+            ):
+                next_idx = j
+                dmin = distmm[idx, j]
+
+        return next_idx
+
+    def getidmax(v1: np.ndarray, probs: np.ndarray, clusterid: int):
+
+        tmpv = np.copy(probs)
+        tmpv[v1 != clusterid] = -np.inf
+        return np.argmax(tmpv)
+
+    def post_process(
+        normpks: float,
+        cluster_centers: np.ndarray,
+        grid_pos: np.ndarray,
+        idxroot: np.ndarray,
+        probs: np.ndarray,
+        cell: np.ndarray,
+        thrpcl: float,
+    ):
+
+        nk = len(cluster_centers)
+        to_merge = np.full(nk, False)
+        for k in range(nk):
+            dummd1 = np.exp(LSE(probs[idxroot == cluster_centers[k]]) - normpks)
+            to_merge[k] = dummd1 > thrpcl
+        # merge the outliers
+        for i in range(nk):
+            if not to_merge[k]:
+                continue
+            dummd1yi1 = cluster_centers[i]
+            dummd1 = np.inf
+            for j in range(nk):
+                if to_merge[k]:
+                    continue
+                dummd2 = pairwise_euclidean_distances(
+                    grid_pos[idxroot[dummd1yi1]], grid_pos[idxroot[j]], cell=cell
+                )
+                if dummd2 < dummd1:
+                    dummd1 = dummd2
+                    cluster_centers[i] = j
+            idxroot[idxroot == dummd1yi1] = cluster_centers[i]
+        if sum(to_merge) > 0:
+            cluster_centers = np.concatenate(
+                np.argwhere(idxroot == np.arange(len(idxroot)))
+            )
+            nk = len(cluster_centers)
+            for i in range(nk):
+                dummd1yi1 = cluster_centers[i]
+                cluster_centers[i] = getidmax(idxroot, probs, cluster_centers[i])
+                idxroot[idxroot == dummd1yi1] = cluster_centers[i]
+
+        return cluster_centers, idxroot
+
+    gabrial = get_gabriel_graph(dist_matrix)
+    idmindist = np.argmin(dist_matrix, axis=1)
+    idxroot = np.full(dist_matrix.shape[0], -1, dtype=int)
+    for i in tqdm(range(dist_matrix.shape[0]), desc="Quick-Shift"):
+        if idxroot[i] != -1:
+            continue
+        qspath = []
+        qspath.append(i)
+        while qspath[-1] != idxroot[qspath[-1]]:
+            if gs > 0:
+                idxroot[qspath[-1]] = gs_next(
+                    qspath[-1], probs, gs, dist_matrix, gabrial
+                )
+            else:
+                idxroot[qspath[-1]] = qs_next(
+                    qspath[-1],
+                    idmindist[qspath[-1]],
+                    probs,
+                    dist_matrix,
+                    cutoff2[qspath[-1]],
+                )
+            if idxroot[idxroot[qspath[-1]]] != -1:
+                break
+            qspath.append(idxroot[qspath[-1]])
+        idxroot[qspath] = idxroot[idxroot[qspath[-1]]]
+    cluster_centers = np.concatenate(
+        np.argwhere(idxroot == np.arange(dist_matrix.shape[0]))
+    )
+
+    return post_process(normpks, cluster_centers, X, idxroot, probs, cell, thrpcl)
+
+
+def get_gabriel_graph(dist_matrix2: np.ndarray):
+    """
+    Generate the Gabriel graph based on the given squared distance matrix.
+
+    Parameters:
+        dist_matrix2 (np.ndarray): The squared distance matrix of shape (n_points, n_points).
+        outputname (Optional[str]): The name of the output file. Default is None.
+
+    Returns:
+        np.ndarray: The Gabriel graph matrix of shape (n_points, n_points).
+
+    """
+
+    n_points = dist_matrix2.shape[0]
+    gabriel = np.full((n_points, n_points), True)
+    for i in tqdm(range(n_points), desc="Calculating Gabriel graph"):
+        gabriel[i, i] = False
+        for j in range(i, n_points):
+            if np.sum(dist_matrix2[i] + dist_matrix2[j] < dist_matrix2[i, j]):
+                gabriel[i, j] = False
+                gabriel[j, i] = False
+
+    return gabriel
+
+
+def rij(period: np.ndarray, xi: np.ndarray, xj: np.ndarray):
+    """
+    Calculates the period-concerned position vector.
+    Args:
+        period (np.ndarray): An array of periods for each dimension of the points.
+        -1 stands for not periodic.
+        xi (np.ndarray): An array of point coordinates. It can also contain many points.
+        Shape: (n_points, n_dimensions)
+        xj (np.ndarray): An array of point coordinates. It can only contain one point.
+
+    Returns:
+        xij (np.ndarray): An array of position vectors. Shape: (n_points, n_dimensions)
+    """
+
+    xij = xi - xj
+    if period is not None:
+        xij -= np.round(xij / period) * period
+
+    return xij

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -2,20 +2,22 @@
 
 from dataclasses import dataclass
 from typing import Optional, Union
-from tqdm import tqdm
 
 import numpy as np
+from tqdm import tqdm
 
 
 class NearestGridAssigner:
     """NearestGridAssigner Class
     Assign descriptor to its nearest grid. This is an axulirary class.
-    
+
     Args:
         cell (np.ndarray): An array of periods for each dimension of the grid.
         exclude_grid (bool): Whether to exclude the grid itself from neighbor lists."""
 
-    def __init__(self, metric, cell: Optional[np.ndarray] = None, exclude_grid: bool = True) -> None:
+    def __init__(
+        self, metric, cell: Optional[np.ndarray] = None, exclude_grid: bool = True
+    ) -> None:
 
         self.labels_ = None
         self.metric = metric
@@ -81,22 +83,20 @@ class GaussianMixtureModel:
         Calculate the probability density function (PDF) value for a given input array.
 
         Parameters:
-            x (np.ndarray): The input array for which the PDF is calculated. Once a point.
-            i (Optional[int]): The index of the element in the PDF array to return.
-                If None, the sum of all elements is returned.
+            x (np.ndarray): The input array for which the PDF
+                is calculated. Once a point.
+            i (Optional[int]): The index of the element in
+                the PDF array to return. If None, the sum of
+                all elements is returned.
 
         Returns:
             float or np.ndarray: The PDF value(s) for the given input(s).
                 If i is None, the sum of all PDF values is returned.
-                If i is specified, the normalized value of the corresponding gaussian is returned.
+                If i is specified, the normalized value of the corresponding
+                Wgaussian is returned.
 
         Raises:
             None
-
-        Example:
-            >>> obj = ClassName()
-            >>> obj.__call__(x, i)
-            0.123456789
         """
 
         if len(x.shape) == 1:
@@ -119,6 +119,7 @@ class GaussianMixtureModel:
 
         return np.sum(p[i]) / sum_p
 
+
 def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
     """
     Calculate the covariance matrix for a given set of grid positions and weights.
@@ -135,8 +136,10 @@ def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
         cov (np.ndarray): The covariance matrix of shape (dimension, dimension).
 
     Note:
-        The function assumes that the grid positions, weights, and total weight are provided correctly.
-        The function handles periodic and non-periodic dimensions differently to calculate the covariance matrix.
+        The function assumes that the grid positions, weights,
+        and total weight are provided correctly. The function handles
+        periodic and non-periodic dimensions differently to calculate
+        the covariance matrix.
     """
 
     totw = np.sum(sample_weights)
@@ -345,7 +348,8 @@ def get_gabriel_graph(dist_matrix2: np.ndarray):
     Generate the Gabriel graph based on the given squared distance matrix.
 
     Parameters:
-        dist_matrix2 (np.ndarray): The squared distance matrix of shape (n_points, n_points).
+        dist_matrix2 (np.ndarray):
+            The squared distance matrix of shape (n_points, n_points).
         outputname (Optional[str]): The name of the output file. Default is None.
 
     Returns:

--- a/src/skmatter/utils/_sparsekde.py
+++ b/src/skmatter/utils/_sparsekde.py
@@ -11,16 +11,16 @@ class NearestGridAssigner:
     """NearestGridAssigner Class
     Assign descriptor to its nearest grid. This is an auxilirary class.
 
-    
+
     Parameters
     ----------
     metric :
-        The metric to use. 
+        The metric to use.
         Currently only `sklearn.metrics.pairwise.pairwise_euclidean_distances`.
     cell : np.ndarray
         An array of periods for each dimension of the grid.
 
-    
+
     Attributes
     ----------
     grid_pos : np.ndarray
@@ -36,7 +36,9 @@ class NearestGridAssigner:
     """
 
     def __init__(
-        self, metric, cell: Optional[np.ndarray] = None,
+        self,
+        metric,
+        cell: Optional[np.ndarray] = None,
     ) -> None:
 
         self.labels_ = None
@@ -49,7 +51,7 @@ class NearestGridAssigner:
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> None:
         """Fit the data.
-        
+
         Parameters
         ----------
             X : np.ndarray
@@ -139,6 +141,7 @@ class GaussianMixtureModel:
         The normalization constants.
 
     """
+
     def __post_init__(self):
         self.dimension = self.means.shape[1]
         self.cov_invs = np.linalg.inv(self.covariances)
@@ -154,7 +157,7 @@ class GaussianMixtureModel:
         x : np.ndarray
             The input array for which the PDF is calculated. Once a point.
         i : int, list[int], optional, default=None
-            The index of the element inthe PDF array to return. 
+            The index of the element inthe PDF array to return.
             If None, the sum of all elements is returned.
 
         Returns
@@ -205,9 +208,9 @@ def covariance(X: np.ndarray, sample_weights: np.ndarray, cell: np.ndarray):
         The covariance matrix of shape (dimension, dimension).
     Notes
     -----
-    The function assumes that the grid positions, weights, 
+    The function assumes that the grid positions, weights,
     and total weight are provided correctly.
-    The function handles periodic and non-periodic dimensions differently to 
+    The function handles periodic and non-periodic dimensions differently to
     calculate the covariance matrix.
     """
 
@@ -354,7 +357,7 @@ def quick_shift(
         The squared distance matrix.
     cutoff2 : np.ndarray
         The squared cutoff array.
-    gs : float 
+    gs : float
         The value of gs.
 
     Returns
@@ -479,7 +482,7 @@ def rij(period: Optional[np.ndarray], xi: np.ndarray, xj: np.ndarray) -> np.ndar
         An array of periods for each dimension of the points.
         None stands for not periodic.
     xi : np.ndarray
-        An array of point coordinates. It can also contain many points. 
+        An array of point coordinates. It can also contain many points.
         Shape: (n_points, n_dimensions)
     xj : np.ndarray
         An array of point coordinates. It can only contain one point.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,6 +12,7 @@ from skmatter.metrics import (
     local_prediction_rigidity,
     local_reconstruction_error,
     pointwise_local_reconstruction_error,
+    pairwise_euclidean_distances,
 )
 
 
@@ -213,6 +214,38 @@ class ReconstructionMeasuresTests(unittest.TestCase):
             f"size {test_size}",
         )
 
+
+class DistanceTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.X = [[1, 2], [3, 4], [5, 6]]
+        cls.Y = [[7, 8], [9, 10]]
+        cls.cell = [5, 7]
+        cls.distances = np.array([[ 8.48528137, 11.3137085 ],
+                                  [ 5.65685425,  8.48528137],
+                                  [ 2.82842712,  5.65685425]])
+        cls.periodic_distances = np.array([[1.41421356, 2.23606798],
+                                           [3.16227766, 1.41421356],
+                                           [2.82842712, 3.16227766]])
+
+    def test_euclidean_distance(self):
+        distances = pairwise_euclidean_distances(self.X, self.Y)
+        self.assertTrue(
+            np.allclose(distances, self.distances),
+            f"Calculated distance does not match expected value"
+            f"Calculated: {distances} Expected: {self.distances}"
+        )
+
+    def test_periodic_euclidean_distance(self):
+        distances = pairwise_euclidean_distances(
+            self.X, self.Y, cell=self.cell
+        )
+        self.assertTrue(
+            np.allclose(distances, self.periodic_distances),
+            f"Calculated distance does not match expected value"
+            f"Calculated: {distances} Expected: {self.periodic_distances}"
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,6 +13,7 @@ from skmatter.metrics import (
     local_reconstruction_error,
     pointwise_local_reconstruction_error,
     pairwise_euclidean_distances,
+    pairwise_mahalanobis_distances,
 )
 
 
@@ -221,31 +222,62 @@ class DistanceTests(unittest.TestCase):
     def setUpClass(cls):
         cls.X = [[1, 2], [3, 4], [5, 6]]
         cls.Y = [[7, 8], [9, 10]]
+        cls.covs = np.array(
+            [
+                [[1, 0.5], [0.5, 1]],
+                [[1, 0.], [0., 1]]
+            ]
+        )
         cls.cell = [5, 7]
-        cls.distances = np.array([[ 8.48528137, 11.3137085 ],
-                                  [ 5.65685425,  8.48528137],
-                                  [ 2.82842712,  5.65685425]])
-        cls.periodic_distances = np.array([[1.41421356, 2.23606798],
-                                           [3.16227766, 1.41421356],
-                                           [2.82842712, 3.16227766]])
+        cls.distances = np.array(
+            [
+                [8.48528137, 11.3137085],
+                [5.65685425, 8.48528137],
+                [2.82842712, 5.65685425],
+            ]
+        )
+        cls.periodic_distances = np.array(
+            [
+                [1.41421356, 2.23606798],
+                [3.16227766, 1.41421356],
+                [2.82842712, 3.16227766],
+            ]
+        )
+        cls.mahalanobis_distances = np.array(
+            [
+                [
+                    [10.39230485, 13.85640646],
+                    [6.92820323, 10.39230485],
+                    [3.46410162, 6.92820323],
+                ],
+            cls.distances,
+            ]
+        )
 
     def test_euclidean_distance(self):
         distances = pairwise_euclidean_distances(self.X, self.Y)
         self.assertTrue(
             np.allclose(distances, self.distances),
             f"Calculated distance does not match expected value"
-            f"Calculated: {distances} Expected: {self.distances}"
+            f"Calculated: {distances} Expected: {self.distances}",
         )
 
     def test_periodic_euclidean_distance(self):
-        distances = pairwise_euclidean_distances(
-            self.X, self.Y, cell=self.cell
-        )
+        distances = pairwise_euclidean_distances(self.X, self.Y, cell=self.cell)
         self.assertTrue(
             np.allclose(distances, self.periodic_distances),
             f"Calculated distance does not match expected value"
-            f"Calculated: {distances} Expected: {self.periodic_distances}"
+            f"Calculated: {distances} Expected: {self.periodic_distances}",
         )
+
+    def test_mahalanobis_distance(self):
+        distances = pairwise_mahalanobis_distances(self.X, self.Y, self.covs)
+        self.assertTrue(
+            np.allclose(distances, self.mahalanobis_distances),
+            f"Calculated distance does not match expected value"
+            f"Calculated: {distances} Expected: {self.mahalanobis_distances}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,9 +11,9 @@ from skmatter.metrics import (
     global_reconstruction_error,
     local_prediction_rigidity,
     local_reconstruction_error,
-    pointwise_local_reconstruction_error,
     pairwise_euclidean_distances,
     pairwise_mahalanobis_distances,
+    pointwise_local_reconstruction_error,
 )
 
 
@@ -222,12 +222,7 @@ class DistanceTests(unittest.TestCase):
     def setUpClass(cls):
         cls.X = [[1, 2], [3, 4], [5, 6]]
         cls.Y = [[7, 8], [9, 10]]
-        cls.covs = np.array(
-            [
-                [[1, 0.5], [0.5, 1]],
-                [[1, 0.], [0., 1]]
-            ]
-        )
+        cls.covs = np.array([[[1, 0.5], [0.5, 1]], [[1, 0.0], [0.0, 1]]])
         cls.cell = [5, 7]
         cls.distances = np.array(
             [
@@ -250,7 +245,7 @@ class DistanceTests(unittest.TestCase):
                     [6.92820323, 10.39230485],
                     [3.46410162, 6.92820323],
                 ],
-            cls.distances,
+                cls.distances,
             ]
         )
 

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -40,9 +40,7 @@ class SparseKDETests(unittest.TestCase):
         cls.expect_covs_periodic = np.array([[[0.72231751, 0.0], [0.0, 0.56106493]]])
 
     def test_sparse_kde(self):
-        estimator = SparseKDE(
-            self.samples, None, fpoints=0.5, qs=0.85
-        )
+        estimator = SparseKDE(self.samples, None, fpoints=0.5, qs=0.85)
         estimator.fit(self.grids)
         self.assertTrue(np.allclose(estimator.cluster_weight, self.expect_weight))
         self.assertTrue(np.allclose(estimator.cluster_mean, self.expect_means))

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -1,0 +1,46 @@
+import unittest
+
+import numpy as np
+
+from skmatter.neighbors import covariance, effdim, oas
+
+class CovarianceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.X = np.array([[1, 2], [3, 3], [4, 6]])
+        cls.expected_cov = np.array([[2.33333333, 2.83333333],
+                                     [2.83333333, 4.33333333]])
+        cls.expected_cov_periodic = np.array([[1.12597216, 0.45645371],
+                                              [0.45645371, 0.82318948]])
+        cls.cell = np.array([3, 3])
+
+    def test_covariance(self):
+        cov = covariance(self.X, np.full(len(self.X), 1 / len(self.X)), None)
+        self.assertTrue(np.allclose(cov, self.expected_cov))
+
+    def test_covariance_periodic(self):
+        cov = covariance(self.X, np.full(len(self.X), 1 / len(self.X)), self.cell)
+        self.assertTrue(np.allclose(cov, self.expected_cov_periodic))
+
+class EffdimTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cov = np.array([[1, 1, 0],
+                            [1, 1, 0],
+                            [0, 0, 1]])
+        cls.expected_effdim = 1.8898815748423097
+
+    def test_effdim(self):
+        self.assertTrue(np.allclose(effdim(self.cov), self.expected_effdim))
+
+class OASTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cov = np.array([[0.5, 1.0], [0.7, 0.4]])
+        cls.n = 10
+        cls.D = 2
+        cls.expected_oas = np.array([[0.48903924, 0.78078484],
+                                     [0.54654939, 0.41096076]])
+
+    def test_oas(self):
+        self.assertTrue(np.allclose(oas(self.cov, self.n, self.D), self.expected_oas))

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -23,14 +23,14 @@ class SparseKDETests(unittest.TestCase):
         )
         cls.selector = FPS(n_to_select=int(np.sqrt(2 * cls.n_samples_per_cov)))
         cls.grids = cls.selector.fit_transform(cls.samples.T).T
-        cls.expect_weight = np.array([0.49888273, 0.50111727])
+        cls.expect_weight = np.array([0.49887635, 0.50112365])
         cls.expect_means = np.array(
-            [[0.01281471, 0.18859686], [4.22711008, 4.36817619]]
+            [[0.01281471, 0.18859686], [4.22711008, 4.36817619]],
         )
         cls.expect_covs = np.array(
             [
-                [[1.12389433, 0.6442742], [0.6442742, 1.13470138]],
-                [[1.05033635, 0.50630466], [0.50630466, 0.53994241]],
+                [[1.12389543, 0.64427576], [0.64427576, 1.1347041]],
+                [[1.05031634, 0.50629971], [0.50629971, 0.53994028]],
             ]
         )
 

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -2,16 +2,80 @@ import unittest
 
 import numpy as np
 
-from skmatter.neighbors import covariance, effdim, oas
+from skmatter.feature_selection import FPS
+from skmatter.neighbors import SparseKDE, covariance, effdim, oas
+
+
+class SparseKDETests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        np.random.seed(0)
+        cls.n_samples_per_cov = 10000
+        cls.samples = np.concatenate(
+            [
+                np.random.multivariate_normal(
+                    [0, 0], [[1, 0.5], [0.5, 1]], cls.n_samples_per_cov
+                ),
+                np.random.multivariate_normal(
+                    [4, 4], [[1, 0.5], [0.5, 0.5]], cls.n_samples_per_cov
+                ),
+            ]
+        )
+        cls.selector = FPS(n_to_select=int(np.sqrt(2 * cls.n_samples_per_cov)))
+        cls.grids = cls.selector.fit_transform(cls.samples.T).T
+        cls.expect_weight = np.array([0.49888273, 0.50111727])
+        cls.expect_means = np.array(
+            [[0.01281471, 0.18859686], [4.22711008, 4.36817619]]
+        )
+        cls.expect_covs = np.array(
+            [
+                [[1.12389433, 0.6442742], [0.6442742, 1.13470138]],
+                [[1.05033635, 0.50630466], [0.50630466, 0.53994241]],
+            ]
+        )
+
+        cls.cell = np.array([4, 4])
+        cls.expect_weight_periodic = np.array([1.0])
+        cls.expect_means_periodic = np.array([[0.01281471, 0.18859686]])
+        cls.expect_covs_periodic = np.array([[[0.72280929, 0.0], [0.0, 0.56174913]]])
+
+    def test_sparse_kde(self):
+        estimator = SparseKDE(
+            "gaussian", "pero", {}, self.samples, None, fpoints=0.5, qs=0.85
+        )
+        estimator.fit(self.grids, igrid=self.selector.selected_idx_)
+        self.assertTrue(np.allclose(estimator.cluster_weight, self.expect_weight))
+        self.assertTrue(np.allclose(estimator.cluster_mean, self.expect_means))
+        self.assertTrue(np.allclose(estimator.cluster_cov, self.expect_covs))
+
+    def test_sparse_kde_periodic(self):
+        estimator = SparseKDE(
+            "gaussian",
+            "pero",
+            {"cell": self.cell},
+            self.samples,
+            None,
+            fpoints=0.5,
+            qs=0.85,
+        )
+        estimator.fit(self.grids, igrid=self.selector.selected_idx_)
+        self.assertTrue(
+            np.allclose(estimator.cluster_weight, self.expect_weight_periodic)
+        )
+        self.assertTrue(np.allclose(estimator.cluster_mean, self.expect_means_periodic))
+        self.assertTrue(np.allclose(estimator.cluster_cov, self.expect_covs_periodic))
+
 
 class CovarianceTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.X = np.array([[1, 2], [3, 3], [4, 6]])
-        cls.expected_cov = np.array([[2.33333333, 2.83333333],
-                                     [2.83333333, 4.33333333]])
-        cls.expected_cov_periodic = np.array([[1.12597216, 0.45645371],
-                                              [0.45645371, 0.82318948]])
+        cls.expected_cov = np.array(
+            [[2.33333333, 2.83333333], [2.83333333, 4.33333333]]
+        )
+        cls.expected_cov_periodic = np.array(
+            [[1.12597216, 0.45645371], [0.45645371, 0.82318948]]
+        )
         cls.cell = np.array([3, 3])
 
     def test_covariance(self):
@@ -22,16 +86,16 @@ class CovarianceTests(unittest.TestCase):
         cov = covariance(self.X, np.full(len(self.X), 1 / len(self.X)), self.cell)
         self.assertTrue(np.allclose(cov, self.expected_cov_periodic))
 
+
 class EffdimTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cov = np.array([[1, 1, 0],
-                            [1, 1, 0],
-                            [0, 0, 1]])
+        cls.cov = np.array([[1, 1, 0], [1, 1, 0], [0, 0, 1]])
         cls.expected_effdim = 1.8898815748423097
 
     def test_effdim(self):
         self.assertTrue(np.allclose(effdim(self.cov), self.expected_effdim))
+
 
 class OASTests(unittest.TestCase):
     @classmethod
@@ -39,8 +103,9 @@ class OASTests(unittest.TestCase):
         cls.cov = np.array([[0.5, 1.0], [0.7, 0.4]])
         cls.n = 10
         cls.D = 2
-        cls.expected_oas = np.array([[0.48903924, 0.78078484],
-                                     [0.54654939, 0.41096076]])
+        cls.expected_oas = np.array(
+            [[0.48903924, 0.78078484], [0.54654939, 0.41096076]]
+        )
 
     def test_oas(self):
         self.assertTrue(np.allclose(oas(self.cov, self.n, self.D), self.expected_oas))

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -23,42 +23,40 @@ class SparseKDETests(unittest.TestCase):
         )
         cls.selector = FPS(n_to_select=int(np.sqrt(2 * cls.n_samples_per_cov)))
         cls.grids = cls.selector.fit_transform(cls.samples.T).T
-        cls.expect_weight = np.array([0.49887635, 0.50112365])
+        cls.expect_weight = np.array([0.49848071, 0.50151929])
         cls.expect_means = np.array(
             [[0.01281471, 0.18859686], [4.22711008, 4.36817619]],
         )
         cls.expect_covs = np.array(
             [
-                [[1.12389543, 0.64427576], [0.64427576, 1.1347041]],
-                [[1.05031634, 0.50629971], [0.50629971, 0.53994028]],
+                [[1.10462777, 0.6370178], [0.6370178, 1.11759455]],
+                [[1.03559702, 0.50091544], [0.50091544, 0.53316178]],
             ]
         )
 
         cls.cell = np.array([4, 4])
         cls.expect_weight_periodic = np.array([1.0])
         cls.expect_means_periodic = np.array([[0.01281471, 0.18859686]])
-        cls.expect_covs_periodic = np.array([[[0.72280929, 0.0], [0.0, 0.56174913]]])
+        cls.expect_covs_periodic = np.array([[[0.72231751, 0.0], [0.0, 0.56106493]]])
 
     def test_sparse_kde(self):
         estimator = SparseKDE(
-            "gaussian", "pero", {}, self.samples, None, fpoints=0.5, qs=0.85
+            self.samples, None, fpoints=0.5, qs=0.85
         )
-        estimator.fit(self.grids, igrid=self.selector.selected_idx_)
+        estimator.fit(self.grids)
         self.assertTrue(np.allclose(estimator.cluster_weight, self.expect_weight))
         self.assertTrue(np.allclose(estimator.cluster_mean, self.expect_means))
         self.assertTrue(np.allclose(estimator.cluster_cov, self.expect_covs))
 
     def test_sparse_kde_periodic(self):
         estimator = SparseKDE(
-            "gaussian",
-            "pero",
-            {"cell": self.cell},
             self.samples,
             None,
+            metric_params={"cell": self.cell},
             fpoints=0.5,
             qs=0.85,
         )
-        estimator.fit(self.grids, igrid=self.selector.selected_idx_)
+        estimator.fit(self.grids)
         self.assertTrue(
             np.allclose(estimator.cluster_weight, self.expect_weight_periodic)
         )


### PR DESCRIPTION
This PR introduces SparseKDE:

- The class `SparseKDE` is located at `src/skmatter/utils/_sparsekde.py`. It mitigates the high cost of doing KDE for large datasets by doing KDE for selected data points (e.g. grid points sampled by farthest point-sampling). This class takes the original dataset as a parameter and fits the model using the sampled grid points.
- There are two auxiliary classes and some auxiliary functions of `SparseKDE` stored in `src/skmatter/utils/_sparsekde.py`.
- Two distance metrics compatible with PBC,  `pairwise_euclidean_distances` and `pairwise_mahalanobis_distances`, are realized and stored in `src/skmatter/metrics/pairwise.py`.
- Tests for `SparseKDE` and some auxiliary functions are stored in `tests/test_neighbors.py`. Tests for distance metrics are stored in `tests/test_metrics.py`.

I am not sure if the current API of `SparseKDE` is OK and if the auxiliary classes should be integrated into `SparseKDE`. Also, `SparseKDE` seems to be too large and complex. Perhaps it needs to be decomposed into smaller parts, but I have not figured out how.


Contributor (creator of PR) checklist
-------------------------------------
 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

For Reviewer
------------
 - [ ] CHANGELOG updated if important change?


<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview scikit-matter end -->