### PR TITLE
Fix codecov ci and add dependabot for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    groups:
+      action-dependencies:
+        patterns:
+          - "*" # A wildcard to create one PR for all dependencies in the ecosystem

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs:
 
     - name: run Python tests
       run: tox -e tests
-    - uses: codecov/codecov-action@v3
+
+    - name: upload to codecov.io
+      uses: codecov/codecov-action@v4
       with:
+        fail_ci_if_error: true
         files: ./tests/coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
 scikit-matter
 =============
-
 |tests| |codecov| |pypi| |conda| |docs| |doi|
 
 A collection of scikit-learn compatible utilities that implement methods born out of the
@@ -14,13 +13,11 @@ For details, tutorials, and examples, please have a look at our `documentation`_
 
 Installation
 ------------
-
 You can install *scikit-matter* either via pip using
 
 .. code-block:: bash
 
     pip install skmatter
-
 
 or conda
 
@@ -28,27 +25,23 @@ or conda
 
     conda install -c conda-forge skmatter
 
-
 You can then ``import skmatter`` and use scikit-matter in your projects!
 
 .. marker-ci-tests
 
 Tests
 -----
+We are testing our code for Python 3.8 and 3.12 on  `Windows Server 2019`_, `macOS 11`_
+and `Ubuntu LTS 22.04`_.
 
-We are testing our code for Python 3.8 and 3.11 on  `Windows Server 2019
-<https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md>`_,
-`macOS 11
-<https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md>`_
-and `Ubuntu LTS 22.04
-<https://github.com/actions/runner-images/
-blob/main/images/linux/Ubuntu2204-Readme.md>`_.
+.. _`Windows Server 2019`: https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md
+.. _`macOS 11`: https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
+.. _`Ubuntu LTS 22.04`: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
 
 .. marker-issues
 
 Having problems or ideas?
 -------------------------
-
 Having a problem with scikit-matter? Please let us know by `submitting an issue
 <https://github.com/scikit-learn-contrib/scikit-matter/issues>`_.
 
@@ -59,7 +52,6 @@ Submit new features or bug fixes through a `pull request
 
 Call for Contributions
 ----------------------
-
 We always welcome new contributors. If you want to help us take a look at our
 `contribution guidelines`_ and afterwards you may start with an open issue marked as
 `good first issue`_.
@@ -84,8 +76,7 @@ Writing code is not the only way to contribute to the project. You can also:
 
 Citing scikit-matter
 --------------------
-
-If you use scikit-matter for your work, please cite:
+If you use *scikit-matter* for your work, please cite:
 
 Goscinski A, Principe VP, Fraux G et al. scikit-matter :
 A Suite of Generalisable Machine Learning Methods Born out of Chemistry
@@ -94,7 +85,6 @@ and Materials Science. Open Res Europe 2023, 3:81.
 
 Contributors
 ------------
-
 Thanks goes to all people that make scikit-matter possible:
 
 .. image:: https://contrib.rocks/image?repo=scikit-learn-contrib/scikit-matter

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,8 @@ commands =
     blackdoc --check --diff {[tox]lint_folders}
     isort --check-only --diff {[tox]lint_folders}
     sphinx-lint --enable line-too-long --max-line-length 88 \
-    -i "{toxinidir}/docs/src/examples" \
-    {[tox]lint_folders} "{toxinidir}/README.rst"
+        -i "{toxinidir}/docs/src/examples" \
+        {[tox]lint_folders} "{toxinidir}/README.rst"
 
 [testenv:{format,format-unsafe}]
 description =


### PR DESCRIPTION
This should fix the codecoverage from the CI job. Before this will work we also have to add the correct `CODECOV_TOKEN` to **settings -> Security -> Secrets and variables -> Actions  in the section “Repository secrets”**. I am not allowed to do this though. Maybe someone with more permissions can add the token.

I also added [Githubs dependabot](https://docs.github.com/en/code-security/dependabot) to help us updating our Github actions 🤖.

<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--226.org.readthedocs.build/en/226/

<!-- readthedocs-preview scikit-matter end -->