### PR TITLE
Bump supported and testes Python versions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,4 +9,4 @@ coverage:
       default:
         target: 90%
 
-comment: off
+comment: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
-    - run: pip install tox
+        python-version: "3.12"
+
+    - name: install tests dependencies
+      run: python -m pip install tox
 
     - name: Test build integrity
       run: tox -e build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,12 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-      - name: install dependencies
-        run: |
-          python -m pip install tox
+          python-version: "3.12"
+
+      - name: install tests dependencies
+        run: python -m pip install tox
+
       - name: build documentation
         run: tox -e docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
-    - run: pip install tox
+        python-version: "3.12"
+
+    - name: install tests dependencies
+      run: python -m pip install tox
 
     - name: Lint the code
       run: tox -e lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,19 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-22.04
-            python-version: "3.8"
-          - os: ubuntu-22.04
-            python-version: "3.11"
-          - os: macos-11
-            python-version: "3.8"
-          - os: macos-11
-            python-version: "3.11"
-          - os: windows-2019
-            python-version: "3.8"
-          - os: windows-2019
-            python-version: "3.11"
+        os: [ubuntu-22.04, macos-14, windows-2022]
+        python-version: ["3.9", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +21,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install tox
+
+    - name: install tests dependencies
+      run: python -m pip install tox
 
     - name: run Python tests
       run: tox -e tests

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
   
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,10 +13,10 @@ The rules for CHANGELOG file:
 
 0.3.0 (XXXX/XX/XX)
 ------------------
+- Supported Python versions are now ranging from 3.9 - 3.12.
 
 0.2.0 (2023/08/24)
 ------------------
-
 - Add this ``CHANGELOG`` file (#198)
 - Update example of WHO feature selection (#212)
 - Rename ``RidgeRegression2FoldCV`` -> ``Ridge2FoldCV`` (#211)
@@ -40,14 +40,12 @@ The rules for CHANGELOG file:
 
 0.1.4 (2023/03/14)
 ------------------
-
 - documentation formatting fixes for math and datasets (#161, #163)
 - changing the way the distance to the convex hull is computed in the
   ``DirectionalConvexHull`` due to numerical issues with the old method (#165)
 
 0.1.3 (2023/03/02)
 ------------------
-
 - Refactor ``scikit-cosmo`` to ``scikit-matter`` (#157, #151)
 - Deprecation warning was added to link to renamed package (#154)
 - dropped Python `<3.8` support, because we are now using ``scikit-learn`` version
@@ -62,7 +60,6 @@ The rules for CHANGELOG file:
 
 0.1.2 (2022/07/04)
 ------------------
-
 - fixed a bug in the orthonormalization step of ``PCov-CUR`` (#118)
 - users can now initialize ``FPS`` selecting using a list of selected points, allowing
   to restart the selection in the middle (#116)
@@ -71,7 +68,6 @@ The rules for CHANGELOG file:
 
 0.1.1 (2021/11/30)
 ------------------
-
 - fixed a bug in the ``orthonormalization`` step of ``PCov-CUR`` (#118)
 - users can now initialize ``FPS`` selecting using a list of selected points, allowing to
   restart the selection in the middle (#116)
@@ -79,7 +75,6 @@ The rules for CHANGELOG file:
 
 0.1.0 (2021/05/12)
 ------------------
-
 - first release out of the lab
 
 .. inclusion-marker-changelog-end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
     {name = "Michele Ceriotti"}
 ]
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -31,10 +31,10 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [

--- a/tests/test_pcovr.py
+++ b/tests/test_pcovr.py
@@ -396,7 +396,7 @@ class PCovRInfrastructureTest(PCovRBaseTest):
         X = self.X.copy() + np.random.uniform(-1, 1, self.X.shape[1])
         with warnings.catch_warnings(record=True) as w:
             pcovr.fit(X, self.Y)
-            self.assertEquals(
+            self.assertEqual(
                 str(w[0].message),
                 "This class does not automatically center data, and your data mean is"
                 " greater than the supplied tolerance.",

--- a/tests/test_sample_pcov_fps.py
+++ b/tests/test_sample_pcov_fps.py
@@ -31,7 +31,7 @@ class TestPCovFPS(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             _ = PCovFPS(n_to_select=1, mixing=1.0)
-        self.assertEquals(
+        self.assertEqual(
             str(cm.exception),
             "Mixing = 1.0 corresponds to traditional FPS." "Please use the FPS class.",
         )

--- a/tests/test_sample_simple_fps.py
+++ b/tests/test_sample_simple_fps.py
@@ -46,9 +46,7 @@ class TestFPS(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             selector = FPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
-        self.assertEquals(
-            str(cm.exception), "Invalid value of the initialize parameter"
-        )
+        self.assertEqual(str(cm.exception), "Invalid value of the initialize parameter")
 
     def test_get_distances(self):
         """

--- a/tests/test_sparse_kernel_centerer.py
+++ b/tests/test_sparse_kernel_centerer.py
@@ -101,7 +101,7 @@ class SparseKernelTests(unittest.TestCase):
         model = model.fit(Knm, Kmm)
         with self.assertRaises(ValueError) as cm:
             model.transform(Knm2)
-        self.assertEquals(
+        self.assertEqual(
             str(cm.exception),
             "The reference kernel and received kernel have different shape",
         )

--- a/tests/test_voronoi_fps.py
+++ b/tests/test_voronoi_fps.py
@@ -39,9 +39,7 @@ class TestVoronoiFPS(TestFPS):
         with self.assertRaises(ValueError) as cm:
             selector = VoronoiFPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
-        self.assertEquals(
-            str(cm.exception), "Invalid value of the initialize parameter"
-        )
+        self.assertEqual(str(cm.exception), "Invalid value of the initialize parameter")
 
     def test_switching_point(self):
         """


### PR DESCRIPTION
Following `sklearn` the new supported Python versions are ranging from `3.9` - `3.12`. I also simplified the syntax in test matrix a bit.

<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview scikit-matter end -->