### PR TITLE
Fix import errors introduced by sklearn 1.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ The rules for CHANGELOG file:
 ------------------
 - Updating ``FPS`` to allow a numpy array of ints as an initialize parameter (#145)
 - Supported Python versions are now ranging from 3.9 - 3.12.
+- Updating ``skmatter.datasets`` submodule to support sklearn 1.5.0 (#229)
 
 0.2.0 (2023/08/24)
 ------------------

--- a/src/skmatter/datasets/_base.py
+++ b/src/skmatter/datasets/_base.py
@@ -1,7 +1,15 @@
 from os.path import dirname, join
 
 import numpy as np
-from sklearn.utils import Bunch, check_pandas_support
+import sklearn
+
+
+if sklearn.__version__ >= "1.5.0":
+    from sklearn.utils._optional_dependencies import check_pandas_support
+else:
+    from sklearn.utils import check_pandas_support
+
+from sklearn.utils import Bunch
 
 
 def load_nice_dataset():

--- a/tests/test_dch.py
+++ b/tests/test_dch.py
@@ -30,7 +30,8 @@ class TestDirectionalConvexHull(unittest.TestCase):
         selector.fit(self.T, self.y)
         self.assertTrue(np.allclose(selector.selected_idx_, self.idx))
 
-        feature_residuals = selector.score_feature_matrix(self.T)
+        # takes abs to avoid numerical noise changing the sign of PCA projections
+        feature_residuals = np.abs(selector.score_feature_matrix(self.T))
         val = np.max(
             np.abs(
                 (self.feature_residuals_100 - feature_residuals[100])


### PR DESCRIPTION
With sklearn version 1.5 the check_pandas_support function has been moved to util._optional_dependencies. This has been adapted in this PR. I would still try to be backwards compatible to 1.* so I put an if then else in the import

<!-- What does this implement/fix? Explain your changes here. -->


Contributor (creator of PR) checklist
-------------------------------------
 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

For Reviewer
------------
 - [x] CHANGELOG updated if important change?


<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--229.org.readthedocs.build/en/229/

<!-- readthedocs-preview scikit-matter end -->