### PR TITLE
Fixing docs card font color for dark mode

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,7 +6,13 @@
         /* Overriding bootstrap font color so that text appears white
            in dark theme */
         html[data-theme="dark"] .card-text {
-            color: #ced6dd;
+            color: var(--pst-color-text-base);
+        }
+
+        /* Overriding bootstrap border color so that border appears white
+           in dark theme */
+        html[data-theme="dark"] .card {
+            --bs-card-border-color: var(--pst-color-border);
         }
     </style>
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -2,6 +2,16 @@
 
 .. raw:: html
 
+     <style>
+        /* Overriding bootstrap font color so that text appears white
+           in dark theme */
+        html[data-theme="dark"] .card-text {
+            color: #ced6dd;
+        }
+    </style>
+
+.. raw:: html
+
     <div class="container">
         <div class="row">
             <div class="col-sm d-flex">


### PR DESCRIPTION
Addresses issue #252: 
<img width="380" alt="Image" src="https://github.com/user-attachments/assets/41e3c61f-c909-4170-8d6e-47b011a39f99" /> <img width="350" alt="Image2" src="https://github.com/user-attachments/assets/e8a3b924-63ae-4b82-a6cd-969bafe923fc" />

Font color and border color for each card should now match the rest of the dark theme.

Contributor (creator of PR) checklist
-------------------------------------
 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

For Reviewer
------------
 - [ ] CHANGELOG updated if important change?


<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview scikit-matter end -->