### PR TITLE
Pin scikit-learn version to <1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "scikit-learn >= 1.6.0",
-    "scipy >= 1.15.0",  # explicit to adhere to scikit-learn dependencies
+    "scikit-learn >= 1.6, < 1.7",
+    "scipy >= 1.15",  # explicit to adhere to scikit-learn dependencies
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Quick fix to get CI running for open PRs.

We should still fix the issues asap...

<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--256.org.readthedocs.build/en/256/

<!-- readthedocs-preview scikit-matter end -->