### PR TITLE
Fix pcovc scaling

### DIFF
--- a/examples/pcovc/KPCovC_Comparison.py
+++ b/examples/pcovc/KPCovC_Comparison.py
@@ -85,7 +85,7 @@ X_test_scaled = scaler.transform(X_test)
 # Both PCA and PCovC fail to produce linearly separable latent space
 # maps. We will need a kernel method to effectively separate the moon classes.
 
-mixing = 0.10
+mixing = 0.5
 alpha_d = 0.5
 alpha_p = 0.4
 

--- a/examples/pcovc/KPCovC_Hyperparameters.py
+++ b/examples/pcovc/KPCovC_Hyperparameters.py
@@ -65,7 +65,7 @@ kernel_params = {
 fig, axs = plt.subplots(2, len(kernels), figsize=(len(kernels) * 4, 8))
 
 center = True
-mixing = 0.10
+mixing = 0.5
 
 for i, kernel in enumerate(kernels):
     kpca = KernelPCA(

--- a/src/skmatter/decomposition/_kernel_pcovc.py
+++ b/src/skmatter/decomposition/_kernel_pcovc.py
@@ -86,7 +86,7 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
         If None, ``sklearn.linear_model.LogisticRegression()``
         is used as the classifier.
     
-    scale_z: boolean, default=True
+    scale_z: bool, default=True
         whether to scale Z to zero mean and unit variance prior to
         eigendecomposition.
 

--- a/src/skmatter/decomposition/_kernel_pcovc.py
+++ b/src/skmatter/decomposition/_kernel_pcovc.py
@@ -15,6 +15,7 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted, validate_data
 from sklearn.linear_model._base import LinearClassifierMixin
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
+from sklearn.preprocessing import StandardScaler
 
 from skmatter.preprocessing import KernelNormalizer
 from skmatter.utils import check_cl_fit
@@ -85,6 +86,10 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
         If a pre-fitted classifier is provided, it is used to compute :math:`{\mathbf{Z}}`.
         If None, ``sklearn.linear_model.LogisticRegression()``
         is used as the classifier.
+    
+    scale_z: boolean, default=True
+        whether to scale Z to zero mean and unit variance prior to
+        eigendecomposition.
 
     kernel : {"linear", "poly", "rbf", "sigmoid", "precomputed"} or callable, default="linear"
         Kernel.
@@ -200,6 +205,7 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
         n_components=None,
         svd_solver="auto",
         classifier=None,
+        scale_z=True,
         kernel="linear",
         gamma=None,
         degree=3,
@@ -229,6 +235,7 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
             fit_inverse_transform=fit_inverse_transform,
         )
         self.classifier = classifier
+        self.scale_z = scale_z
 
     def fit(self, X, Y, W=None):
         r"""Fit the model with X and Y.
@@ -323,6 +330,8 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
                 W = LogisticRegression().fit(K, Y).coef_.T
 
         Z = K @ W
+        if self.scale_z:
+            Z = StandardScaler().fit_transform(Z)
 
         self._fit(K, Z, W)
 

--- a/src/skmatter/decomposition/_kernel_pcovc.py
+++ b/src/skmatter/decomposition/_kernel_pcovc.py
@@ -15,9 +15,8 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted, validate_data
 from sklearn.linear_model._base import LinearClassifierMixin
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
-from sklearn.preprocessing import StandardScaler
 
-from skmatter.preprocessing import KernelNormalizer
+from skmatter.preprocessing import KernelNormalizer, StandardFlexibleScaler
 from skmatter.utils import check_cl_fit
 from skmatter.decomposition import _BaseKPCov
 
@@ -331,7 +330,7 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
 
         Z = K @ W
         if self.scale_z:
-            Z = StandardScaler().fit_transform(Z)
+            Z = StandardFlexibleScaler().fit_transform(Z)
 
         self._fit(K, Z, W)
 

--- a/src/skmatter/decomposition/_kernel_pcovc.py
+++ b/src/skmatter/decomposition/_kernel_pcovc.py
@@ -87,7 +87,7 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
         is used as the classifier.
 
     scale_z: bool, default=True
-        whether to scale Z prior to eigendecomposition.
+        Whether to scale Z prior to eigendecomposition.
 
     kernel : {"linear", "poly", "rbf", "sigmoid", "precomputed"} or callable, default="linear"
         Kernel.

--- a/src/skmatter/decomposition/_kernel_pcovc.py
+++ b/src/skmatter/decomposition/_kernel_pcovc.py
@@ -85,10 +85,9 @@ class KernelPCovC(LinearClassifierMixin, _BaseKPCov):
         If a pre-fitted classifier is provided, it is used to compute :math:`{\mathbf{Z}}`.
         If None, ``sklearn.linear_model.LogisticRegression()``
         is used as the classifier.
-    
+
     scale_z: bool, default=True
-        whether to scale Z to zero mean and unit variance prior to
-        eigendecomposition.
+        whether to scale Z prior to eigendecomposition.
 
     kernel : {"linear", "poly", "rbf", "sigmoid", "precomputed"} or callable, default="linear"
         Kernel.

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -125,7 +125,7 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         is used as the classifier.
 
     scale_z: bool, default=True
-        whether to scale Z to zero prior to eigendecomposition.
+        whether to scale Z prior to eigendecomposition.
 
     iterated_power : int or 'auto', default='auto'
         Number of iterations for the power method computed by

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -123,10 +123,9 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         training data as the composite estimator.
         If None, ``sklearn.linear_model.LogisticRegression()``
         is used as the classifier.
-    
+
     scale_z: bool, default=True
-        whether to scale Z to zero mean and unit variance prior to
-        eigendecomposition.
+        whether to scale Z to zero prior to eigendecomposition.
 
     iterated_power : int or 'auto', default='auto'
         Number of iterations for the power method computed by
@@ -219,7 +218,6 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         iterated_power="auto",
         random_state=None,
         whiten=False,
-        
     ):
         super().__init__(
             mixing=mixing,

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -124,7 +124,7 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         If None, ``sklearn.linear_model.LogisticRegression()``
         is used as the classifier.
     
-    scale_z: boolean, default=True
+    scale_z: bool, default=True
         whether to scale Z to zero mean and unit variance prior to
         eigendecomposition.
 

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -16,6 +16,7 @@ from sklearn.utils.multiclass import check_classification_targets, type_of_targe
 from sklearn.utils.validation import check_is_fitted, validate_data
 from skmatter.decomposition import _BasePCov
 from skmatter.utils import check_cl_fit
+from sklearn.preprocessing import StandardScaler
 
 
 class PCovC(LinearClassifierMixin, _BasePCov):
@@ -122,6 +123,10 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         training data as the composite estimator.
         If None, ``sklearn.linear_model.LogisticRegression()``
         is used as the classifier.
+    
+    scale_z: boolean, default=True
+        whether to scale Z to zero mean and unit variance prior to
+        eigendecomposition.
 
     iterated_power : int or 'auto', default='auto'
         Number of iterations for the power method computed by
@@ -210,9 +215,11 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         tol=1e-12,
         space="auto",
         classifier=None,
+        scale_z=True,
         iterated_power="auto",
         random_state=None,
         whiten=False,
+        
     ):
         super().__init__(
             mixing=mixing,
@@ -225,6 +232,7 @@ class PCovC(LinearClassifierMixin, _BasePCov):
             whiten=whiten,
         )
         self.classifier = classifier
+        self.scale_z = scale_z
 
     def fit(self, X, Y, W=None):
         r"""Fit the model with X and Y.
@@ -300,6 +308,8 @@ class PCovC(LinearClassifierMixin, _BasePCov):
                 W = LogisticRegression().fit(X, Y).coef_.T
 
         Z = X @ W
+        if self.scale_z:
+            Z = StandardScaler().fit_transform(Z)
 
         if self.space_ == "feature":
             self._fit_feature_space(X, Y, Z)

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -299,7 +299,7 @@ class PCovC(LinearClassifierMixin, _BasePCov):
                 classifier = self.classifier
 
             self.z_classifier_ = check_cl_fit(classifier, X, Y)
-            W = self.z_classifier_.coef_.T
+            W = self.z_classifier_.coef_.T.copy()
 
         else:
             # If precomputed, use default classifier to predict Y from T
@@ -308,8 +308,11 @@ class PCovC(LinearClassifierMixin, _BasePCov):
                 W = LogisticRegression().fit(X, Y).coef_.T
 
         Z = X @ W
+
         if self.scale_z:
-            Z = StandardScaler().fit_transform(Z)
+            z_scaler = StandardScaler().fit(Z)
+            Z = z_scaler.transform(Z)
+            W /= np.sqrt(z_scaler.var_).reshape(1, -1)
 
         if self.space_ == "feature":
             self._fit_feature_space(X, Y, Z)

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -125,7 +125,7 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         is used as the classifier.
 
     scale_z: bool, default=True
-        whether to scale Z prior to eigendecomposition.
+        Whether to scale Z prior to eigendecomposition.
 
     iterated_power : int or 'auto', default='auto'
         Number of iterations for the power method computed by

--- a/src/skmatter/decomposition/_pcovc.py
+++ b/src/skmatter/decomposition/_pcovc.py
@@ -16,7 +16,7 @@ from sklearn.utils.multiclass import check_classification_targets, type_of_targe
 from sklearn.utils.validation import check_is_fitted, validate_data
 from skmatter.decomposition import _BasePCov
 from skmatter.utils import check_cl_fit
-from sklearn.preprocessing import StandardScaler
+from skmatter.preprocessing import StandardFlexibleScaler
 
 
 class PCovC(LinearClassifierMixin, _BasePCov):
@@ -310,9 +310,9 @@ class PCovC(LinearClassifierMixin, _BasePCov):
         Z = X @ W
 
         if self.scale_z:
-            z_scaler = StandardScaler().fit(Z)
+            z_scaler = StandardFlexibleScaler().fit(Z)
             Z = z_scaler.transform(Z)
-            W /= np.sqrt(z_scaler.var_).reshape(1, -1)
+            W /= z_scaler.scale_.reshape(1, -1)
 
         if self.space_ == "feature":
             self._fit_feature_space(X, Y, Z)

--- a/tests/test_kernel_pcovc.py
+++ b/tests/test_kernel_pcovc.py
@@ -327,6 +327,15 @@ class KernelPCovCInfrastructureTest(KernelPCovCBaseTest):
         self.assertTrue(np.linalg.norm(t3 - t2) < self.error_tol)
         self.assertTrue(np.linalg.norm(t3 - t1) < self.error_tol)
 
+    def test_scale_z_parameter(self):
+        """Check that changing scale_z changes the eigendecomposition."""
+        kpcovc_scaled = self.model(scale_z=True)
+        kpcovc_scaled.fit(self.X, self.Y)
+
+        kpcovc_unscaled = self.model(scale_z=False)
+        kpcovc_unscaled.fit(self.X, self.Y)
+        assert not np.allclose(kpcovc_scaled.pkt_, kpcovc_unscaled.pkt_)
+
 
 class KernelTests(KernelPCovCBaseTest):
     def test_kernel_types(self):

--- a/tests/test_pcovc.py
+++ b/tests/test_pcovc.py
@@ -578,6 +578,17 @@ class PCovCInfrastructureTest(PCovCBaseTest):
             % (len(pcovc_multi.classes_), self.X.shape[1], cl_binary.coef_.shape),
         )
 
+    def test_scale_z_parameter(self):
+        """Check that changing scale_z changes the eigendecomposition."""
+        pcovc_scaled = self.model(scale_z=True)
+        pcovc_scaled.fit(self.X, self.Y)
+
+        pcovc_unscaled = self.model(scale_z=False)
+        pcovc_unscaled.fit(self.X, self.Y)
+        assert not np.allclose(
+            pcovc_scaled.singular_values_, pcovc_unscaled.singular_values_
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_pcovc.py
+++ b/tests/test_pcovc.py
@@ -465,7 +465,8 @@ class PCovCInfrastructureTest(PCovCBaseTest):
 
     def test_prefit_classifier(self):
         """Check that a passed prefit classifier is not modified in
-        PCovC's `fit` call."""
+        PCovC's `fit` call.
+        """
         classifier = LinearSVC()
         classifier.fit(self.X, self.Y)
         pcovc = self.model(mixing=0.5, classifier=classifier)

--- a/tests/test_pcovc.py
+++ b/tests/test_pcovc.py
@@ -464,6 +464,8 @@ class PCovCInfrastructureTest(PCovCBaseTest):
         self.assertEqual(pcovc.n_components_, min(self.X.shape))
 
     def test_prefit_classifier(self):
+        """Check that a passed prefit classifier is not modified in
+        PCovC's `fit` call."""
         classifier = LinearSVC()
         classifier.fit(self.X, self.Y)
         pcovc = self.model(mixing=0.5, classifier=classifier)


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

In some instances of using PCovC, the latent space will "converge" very quickly with changing alpha. This happens because Z is not necessarily O(1) when computed within the `fit` call. This PR solves this by adding a StandardFlexibleScaler call within `fit` that scales Z and W. This will break backwards compatibility but can be made backwards compatible by using `scale_z=False`.

Contributor (creator of PR) checklist
-------------------------------------
 - [X] Tests updated (for new features and bugfixes)?
 - [X] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

For Reviewer
------------
 - [ ] CHANGELOG updated if important change?
