### PR TITLE
Treat warnings as errors in tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ The rules for CHANGELOG file:
 
 Unreleased
 ----------
+- Fix a couple of ``DeprecationWarnings`` and ``UserWarnings`` (#280)
 - Fix PCovC scaling (#270)
 - Refactor of reconstruction measures(#275)
 - Code cleanup of Base classes (#264)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,16 @@ include = [
 output = 'tests/coverage.xml'
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
 addopts = [
     "--cov",
     "--cov-append",
     "--cov-report=",
     "--import-mode=append",
 ]
+# filterwarnings = [
+#     "error",
+# ]
+testpaths = ["tests"]
 
 [tool.ruff]
 exclude = ["docs/src/examples/", "src/torchpme/_version.py"]

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -1019,7 +1019,7 @@ class _FPS(GreedySelector):
             )
 
         # update in-place the Hausdorff distance list
-        np.minimum(self.hausdorff_, new_dist, self.hausdorff_)
+        np.minimum(self.hausdorff_, new_dist, out=self.hausdorff_)
 
     def _update_post_selection(self, X, y, last_selected):
         """
@@ -1163,7 +1163,7 @@ class _PCovFPS(GreedySelector):
         )
 
         # update in-place the Hausdorff distance list
-        np.minimum(self.hausdorff_, new_dist, self.hausdorff_)
+        np.minimum(self.hausdorff_, new_dist, out=self.hausdorff_)
 
     def _update_post_selection(self, X, y, last_selected):
         """Saves the most recent selections, increments the counter, and, recomputes

--- a/src/skmatter/decomposition/_kpcov.py
+++ b/src/skmatter/decomposition/_kpcov.py
@@ -12,7 +12,7 @@ from sklearn.linear_model._base import LinearModel
 from sklearn.decomposition._pca import _infer_dimension
 from sklearn.utils import check_random_state
 from sklearn.utils._arpack import _init_arpack_v0
-from sklearn.utils.extmath import randomized_svd, stable_cumsum, svd_flip
+from sklearn.utils.extmath import randomized_svd, svd_flip
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.validation import validate_data
 from sklearn.metrics.pairwise import pairwise_kernels
@@ -258,7 +258,7 @@ class _BaseKPCov(_BasePCA, LinearModel, metaclass=ABCMeta):
             # side='right' ensures that number of features selected
             # their variance is always greater than self.n_components_ float
             # passed. More discussion in issue: #15669
-            ratio_cumsum = stable_cumsum(explained_variance_ratio_)
+            ratio_cumsum = np.cumulative_sum(explained_variance_ratio_)
             self.n_components_ = (
                 np.searchsorted(ratio_cumsum, self.n_components_, side="right") + 1
             )

--- a/src/skmatter/decomposition/_pcov.py
+++ b/src/skmatter/decomposition/_pcov.py
@@ -14,7 +14,7 @@ from sklearn.decomposition._pca import _infer_dimension
 from sklearn.linear_model._base import LinearModel
 from sklearn.utils import check_random_state
 from sklearn.utils._arpack import _init_arpack_v0
-from sklearn.utils.extmath import randomized_svd, stable_cumsum, svd_flip
+from sklearn.utils.extmath import randomized_svd, svd_flip
 from sklearn.utils.validation import check_is_fitted
 
 from skmatter.utils import pcovr_covariance, pcovr_kernel
@@ -288,7 +288,7 @@ class _BasePCov(_BasePCA, LinearModel, metaclass=ABCMeta):
             # side='right' ensures that number of features selected
             # their variance is always greater than self.n_components_ float
             # passed. More discussion in issue: #15669
-            ratio_cumsum = stable_cumsum(explained_variance_ratio_)
+            ratio_cumsum = np.cumulative_sum(explained_variance_ratio_)
             self.n_components_ = (
                 np.searchsorted(ratio_cumsum, self.n_components_, side="right") + 1
             )

--- a/src/skmatter/sample_selection/_voronoi_fps.py
+++ b/src/skmatter/sample_selection/_voronoi_fps.py
@@ -312,7 +312,7 @@ class VoronoiFPS(GreedySelector):
 
             updated_points = np.where(self.new_dist_ < self.hausdorff_)[0]
             np.minimum(
-                self.hausdorff_, self.new_dist_, self.hausdorff_, casting="unsafe"
+                self.hausdorff_, self.new_dist_, out=self.hausdorff_, casting="unsafe"
             )
         else:
             updated_points = np.array([])

--- a/tests/test_kernel_pcovc.py
+++ b/tests/test_kernel_pcovc.py
@@ -10,6 +10,7 @@ from sklearn.utils.validation import check_X_y
 from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LogisticRegression, RidgeClassifier
 from sklearn.metrics.pairwise import pairwise_kernels
+import pytest
 
 from skmatter.decomposition import KernelPCovC
 
@@ -337,6 +338,7 @@ class KernelPCovCInfrastructureTest(KernelPCovCBaseTest):
 
         kpcovc_unscaled = self.model(scale_z=False)
         kpcovc_unscaled.fit(self.X, self.Y)
+
         assert not np.allclose(kpcovc_scaled.pkt_, kpcovc_unscaled.pkt_)
 
     def test_z_scaling(self):
@@ -345,11 +347,7 @@ class KernelPCovCInfrastructureTest(KernelPCovCBaseTest):
         if it is.
         """
         kpcovc = self.model(n_components=2, scale_z=True)
-
-        with warnings.catch_warnings():
-            kpcovc.fit(self.X, self.Y)
-            warnings.simplefilter("error")
-            self.assertEqual(1 + 1, 2)
+        kpcovc.fit(self.X, self.Y)
 
         kpcovc = self.model(n_components=2, scale_z=False, z_mean_tol=0, z_var_tol=0)
 


### PR DESCRIPTION
Fixes #279

Enable that warnings are treated as errors in the testsuite.

I fixed a couple of warnings in main code that would probably hit us badly in the next release of sklearn...

Also, I adjusted some tests for catching warnings using the `pytest.warns` context manager but there are a lot more. Maybe if @cajchristian or someone else from @rosecers' team can help with fixing them. Almost all of them are very easy to fix


Contributor (creator of PR) checklist
-------------------------------------
 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

For Reviewer
------------
 - [ ] CHANGELOG updated if important change?


<!-- readthedocs-preview scikit-matter start -->
----
📚 Documentation preview 📚: https://scikit-matter--280.org.readthedocs.build/en/280/

<!-- readthedocs-preview scikit-matter end -->